### PR TITLE
Add lean-action caching to Test Extractor and Deploy Documentation action

### DIFF
--- a/.github/workflows/lean_build.yml
+++ b/.github/workflows/lean_build.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-R -Kwerror"
+          build-args: "-Kwerror"
           use-mathlib-cache: true
           use-github-cache: true

--- a/.github/workflows/lean_build.yml
+++ b/.github/workflows/lean_build.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-Kwerror"
+          build-args: "-R -Kwerror"
           use-mathlib-cache: true
           use-github-cache: true

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -38,7 +38,7 @@ jobs:
           use-github-cache: true
       - name: build docs
         run: |
-          lake build -Kwerror -Kenv=doc SampCert:docs
+          lake build -R -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,11 +32,12 @@ jobs:
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-Kwerror -Kenv=doc"
+          build-args: "-R -Kwerror -Kenv=doc"
           use-mathlib-cache: true
           use-github-cache: true
       - name: build docs
         run: |
+          lake -R -Kenv=doc -Kdoc=on update doc-gen4
           lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,13 +29,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-# This step stops us from recompiling mathlib, even though we still need to compile the mathlib docs
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-R -Kwerror -Kenv=doc" # IDK if these are necessary
+          build-args: "-R -Kwerror -Kenv=doc" # IDK if these are necessary?
           use-mathlib-cache: true
-          use-github-cache: true
       - name: build docs
         run: |
           lake build -R -Kwerror -Kenv=doc SampCert:docs

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-R -Kwerror -Kenv=doc SampCert:docs"
+          build-args: "-R -Kwerror -Kenv=doc -Kdoc=on SampCert:docs"
           use-mathlib-cache: true
           use-github-cache: true
 #       - name: build docs

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -27,18 +27,22 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install elan
-        run: |
-          set -o pipefail
-          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          ./elan-init -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - uses: actions/checkout@v4
-      - name: build std
-        id: build
-        run: lake build -Kwerror -Kenv=doc SampCert:docs
+      # Build SampCert
+      # lean-action cannot execute without running lake build yet, but building the project
+      # twice is still faster than rebuilding mathlib
+      - name: build SampCert
+        uses: leanprover/lean-action@v1-beta
+        with:
+          test: false
+          build-args: "-Kwerror"
+          use-mathlib-cache: true
+          use-github-cache: true
+     - name: build docs
+       id: build
+       run: lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -32,13 +32,13 @@ jobs:
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-R -Kwerror -Kenv=doc"
+          build-args: "-R -Kwerror -Kenv=doc SampCert:docs"
           use-mathlib-cache: true
           use-github-cache: true
-      - name: build docs
-        run: |
-          lake -R -Kenv=doc -Kdoc=on update doc-gen4
-          lake build -Kwerror -Kenv=doc SampCert:docs
+#       - name: build docs
+#         run: |
+#           lake -R -Kenv=doc -Kdoc=on update doc-gen4
+#           lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,16 +29,16 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
+# This step stops us from recompiling mathlib, even though we still need to compile the mathlib docs
       - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-R -Kwerror -Kenv=doc -Kdoc=on SampCert:docs"
+          build-args: "-R -Kwerror -Kenv=doc" # IDK if these are necessary
           use-mathlib-cache: true
           use-github-cache: true
-#       - name: build docs
-#         run: |
-#           lake -R -Kenv=doc -Kdoc=on update doc-gen4
-#           lake build -Kwerror -Kenv=doc SampCert:docs
+      - name: build docs
+        run: |
+          lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -29,17 +29,15 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup Pages
         uses: actions/configure-pages@v5
-      - uses: actions/checkout@v4
-      - name: build SampCert
-        uses: leanprover/lean-action@v1-beta
+      - uses: leanprover/lean-action@v1-beta
         with:
           test: false
-          build-args: "-Kwerror"
+          build-args: "-Kwerror -Kenv=doc"
           use-mathlib-cache: true
           use-github-cache: true
       - name: build docs
-        id: build
-        run: lake build -Kwerror -Kenv=doc SampCert:docs
+        run: |
+          lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,9 +30,6 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - uses: actions/checkout@v4
-      # Build SampCert
-      # lean-action cannot execute without running lake build yet, but building the project
-      # twice is still faster than rebuilding mathlib
       - name: build SampCert
         uses: leanprover/lean-action@v1-beta
         with:
@@ -40,9 +37,9 @@ jobs:
           build-args: "-Kwerror"
           use-mathlib-cache: true
           use-github-cache: true
-     - name: build docs
-       id: build
-       run: lake build -Kwerror -Kenv=doc SampCert:docs
+      - name: build docs
+        id: build
+        run: lake build -Kwerror -Kenv=doc SampCert:docs
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
           test: false
           use-mathlib-cache: true
           use-github-cache: true
-          build-args: "-R -Kwerror"
+          build-args: "-Kwerror"
 
       - name: build FastExtract
         run: |
-          lake build -R -Kwerror FastExtract
+          lake build -Kwerror FastExtract
 
       - name: build Python version of SampCert
         run: dafny/dafny build --target:py Tests/SampCert.dfy Tests/Random.py Tests/testing-kolmogorov-discretegaussian.py -o Tests/SampCert.dfy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,11 @@ jobs:
           test: false
           use-mathlib-cache: true
           use-github-cache: true
-          build-args: "-Kwerror FastExtract"
+          build-args: "-Kwerror"
+
+      - name: build FastExtract
+        run: |
+          lake build -Kwerror FastExtract
 
       - name: build Python version of SampCert
         run: dafny/dafny build --target:py Tests/SampCert.dfy Tests/Random.py Tests/testing-kolmogorov-discretegaussian.py -o Tests/SampCert.dfy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,13 +11,6 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - name: install elan
-        run: |
-          set -o pipefail
-          curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-          ./elan-init -y --default-toolchain none
-          echo "$HOME/.elan/bin" >> $GITHUB_PATH
-
       - uses: actions/checkout@v4
 
       - name: install Dafny
@@ -26,9 +19,12 @@ jobs:
       - name: install Python dependences
         run: pip install matplotlib numpy scipy
 
-      - name: build std
-        id: build
-        run: lake build -Kwerror FastExtract
+      - uses: leanprover/lean-action@v1-beta
+        with:
+          test: false
+          use-mathlib-cache: true
+          use-github-cache: true
+          build-args: "-Kwerror FastExtract"
 
       - name: build Python version of SampCert
         run: dafny/dafny build --target:py Tests/SampCert.dfy Tests/Random.py Tests/testing-kolmogorov-discretegaussian.py -o Tests/SampCert.dfy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,11 +24,11 @@ jobs:
           test: false
           use-mathlib-cache: true
           use-github-cache: true
-          build-args: "-Kwerror"
+          build-args: "-R -Kwerror"
 
       - name: build FastExtract
         run: |
-          lake build -Kwerror FastExtract
+          lake build -R -Kwerror FastExtract
 
       - name: build Python version of SampCert
         run: dafny/dafny build --target:py Tests/SampCert.dfy Tests/Random.py Tests/testing-kolmogorov-discretegaussian.py -o Tests/SampCert.dfy

--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 A verified implementation using [Lean](https://github.com/leanprover/lean4) and [Mathlib](https://github.com/leanprover-community/mathlib4) of [the discrete Gaussian sampler for differential privacy](https://arxiv.org/abs/2004.00010), the composition and postprocessing of zero concentrated differential privacy, and some simple queries.
 
-The Lean implementation is not computable because algorithms that terminate with probability 1 are defined using a combinator. However, the code can be extracted to [Dafny](https://dafny.org/) and used as part of the [VMC library](https://github.com/dafny-lang/Dafny-VMC).  
+The Lean implementation is not computable because algorithms that terminate with probability 1 are defined using a combinator. However, the code can be extracted to [Dafny](https://dafny.org/) and used as part of the [VMC library](https://github.com/dafny-lang/Dafny-VMC).
 
 Contributors: Jean-Baptiste Tristan, Leo de Moura, Anjali Joshi, Joseph Tassarotti.


### PR DESCRIPTION
Deploy Documentation action is still not perfect, since it recompiles the mathlib documentation (it would be ideal to cache or eliminate this, so only SampCert documentation is rebuilt). However, this still significantly reduces the deploy time: testing the extractor now takes 1-5 minutes, and building the documentation takes about 15. 