### PR TITLE
Prob uniform byte

### DIFF
--- a/SampCert/Foundations/Basic.lean
+++ b/SampCert/Foundations/Basic.lean
@@ -9,3 +9,4 @@ import SampCert.Foundations.Monad
 import SampCert.Foundations.While
 import SampCert.Foundations.Until
 import SampCert.Foundations.UniformP2
+import SampCert.Foundations.UniformByte

--- a/SampCert/Foundations/UniformByte.lean
+++ b/SampCert/Foundations/UniformByte.lean
@@ -1,0 +1,43 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jean-Baptiste Tristan
+-/
+import SampCert.SLang
+import SampCert.Util.Util
+import SampCert.Foundations.Auto
+
+/-!
+# ``probUniformByte`` Properties
+
+This file contains lemmas about ``probUniformByte``, a ``SLang`` sampler for the
+uniform distribution on bytes.
+-/
+
+
+open Classical Nat PMF
+
+namespace SLang
+
+def probUniformByte_normalizes : HasSum probUniformByte 1 := by
+  rw [Summable.hasSum_iff ENNReal.summable]
+  unfold SLang.probUniformByte
+  rw [division_def]
+  rw [ENNReal.tsum_mul_right]
+  simp only [Nat.cast_ofNat]
+  apply (ENNReal.toReal_eq_one_iff _).mp
+  simp only [ENNReal.toReal_mul]
+  rw [ENNReal.tsum_toReal_eq ?G1]
+  case G1 => simp
+  simp only [ENNReal.one_toReal, tsum_const, nsmul_eq_mul, mul_one]
+  rw [@Nat.card_eq_of_equiv_fin UInt8 256 ?G1]
+  case G1 =>
+    apply Equiv.ofBijective (fun v => v.val)
+    apply Function.bijective_iff_has_inverse.mpr
+    exists (fun v => {val := v : UInt8})
+    simp [Function.RightInverse, Function.LeftInverse]
+  simp [ENNReal.toReal_inv]
+
+def probUniformByte_PMF : PMF UInt8 := ⟨ probUniformByte, probUniformByte_normalizes ⟩
+
+end SLang

--- a/SampCert/SLang.lean
+++ b/SampCert/SLang.lean
@@ -76,11 +76,17 @@ instance : Monad SLang where
   pure a := probPure a
   bind pa pb := pa.probBind pb
 
+
+/--
+Uniform distribution on a byte
+-/
+@[extern "prob_UniformByte"]
+def probUniformByte : SLang UInt8 := (fun _ => 1 / UInt8.size)
+
 /--
 ``SLang`` value for the uniform distribution over ``m`` elements, where
 the number``m`` is the largest power of two that is at most ``n``.
 -/
--- MARKUSDE: I would like to change this to ``probUniformP2`` once it doesn't break extraction.
 @[extern "prob_UniformP2"]
 def UniformPowerOfTwoSample (n : ℕ+) : SLang ℕ :=
   toSLang (PMF.uniformOfFintype (Fin (2 ^ (log 2 n))))

--- a/SampCertCheck.lean
+++ b/SampCertCheck.lean
@@ -1,0 +1,15 @@
+/-
+Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jean-Baptiste Tristan
+-/
+import SampCert
+import SampCert.SLang
+
+-- Entry point to check properties of the FFI
+
+def main : IO Unit := do
+  -- Check if FFI is working
+  IO.print "Sampling byte: "
+  let x <- PMF.run <| SLang.probUniformByte_PMF
+  IO.println x

--- a/SampCertCheck.lean
+++ b/SampCertCheck.lean
@@ -10,6 +10,7 @@ import SampCert.SLang
 
 def main : IO Unit := do
   -- Check if FFI is working
-  IO.print "Sampling byte: "
-  let x <- PMF.run <| SLang.probUniformByte_PMF
-  IO.println x
+  IO.print "Sampling bytes: "
+  for _ in [:10000] do
+    let x <- PMF.run <| SLang.probUniformByte_PMF
+    IO.println x

--- a/ffi.cpp
+++ b/ffi.cpp
@@ -4,6 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jean-Baptiste Tristan
 */
 #include <lean/lean.h>
+#include <fcntl.h>
+#include <unistd.h>
 #include <random>
 
 #ifdef __APPLE__
@@ -11,6 +13,19 @@ Authors: Jean-Baptiste Tristan
 #else
     std::mt19937_64 generator(time(NULL));
 #endif
+
+extern "C" lean_object * prob_UniformByte (lean_object * eta) {
+    lean_dec(eta);
+    unsigned char r;
+    int urandom = open("/dev/urandom", O_RDONLY | O_CLOEXEC);
+    if (urandom == -1) {
+        lean_internal_panic("prob_UniformByte: /dev/urandom cannot be opened");
+    }
+    read(urandom, &r,1);
+    close(urandom);
+    return lean_box((size_t) r);
+}
+
 
 extern "C" lean_object * prob_UniformP2(lean_object * a, lean_object * eta) {
     lean_dec(eta);

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -39,3 +39,8 @@ lean_exe test where
   root := `Test
   extraDepTargets := #[`libleanffi]
   moreLinkArgs := #["-L.lake/build/lib", "-lleanffi"]
+
+lean_exe check where
+  root := `SampCertCheck
+  extraDepTargets := #[`libleanffi]
+  moreLinkArgs := #["-L.lake/build/lib", "-lleanffi"]


### PR DESCRIPTION
* stub FFI call for UniformByteArray

* prob_UniformByte

* Remove standard library dependency from prob_UniformByte

* Cleanup

* Changes

* insert size_t cast

* UniformByte normalizes