### PR TITLE
Restructure definitions of DP

### DIFF
--- a/SampCert.lean
+++ b/SampCert.lean
@@ -14,7 +14,7 @@ import Init.Data.UInt.Lemmas
 
 open SLang PMF
 
-def combineConcentrated := @privNoisedBoundedMean_DP gaussian_zCDPSystem
+def combineConcentrated := @privNoisedBoundedMean_DP _ gaussian_zCDPSystem
 def combinePure := @privNoisedBoundedMean_DP PureDPSystem
 
 /-
@@ -41,7 +41,7 @@ Return an upper bound on the bin value, clipped to 2^(1 + numBins)
 def unbin (n : Fin numBins) : ℕ+ := 2 ^ (1 + n.val)
 
 noncomputable def combineMeanHistogram : Mechanism ℕ (Option ℚ) :=
-  privMeanHistogram PureDPSystem numBins { bin } unbin 1 20 2 1 20
+  privMeanHistogram PureDPSystem laplace_pureDPSystem numBins { bin } unbin 1 20 2 1 20
 
 end histogramMeanExample
 

--- a/SampCert.lean
+++ b/SampCert.lean
@@ -40,7 +40,7 @@ Return an upper bound on the bin value, clipped to 2^(1 + numBins)
 -/
 def unbin (n : Fin numBins) : ℕ+ := 2 ^ (1 + n.val)
 
-noncomputable def combineMeanHistogram : Mechanism ℕ (Option ℚ) :=
+def combineMeanHistogram : Mechanism ℕ (Option ℚ) :=
   privMeanHistogram PureDPSystem laplace_pureDPSystem numBins { bin } unbin 1 20 2 1 20
 
 end histogramMeanExample

--- a/SampCert.lean
+++ b/SampCert.lean
@@ -14,7 +14,7 @@ import Init.Data.UInt.Lemmas
 
 open SLang PMF
 
-def combineConcentrated := @privNoisedBoundedMean_DP _ gaussian_zCDPSystem
+def combineConcentrated := @privNoisedBoundedMean_DP zCDPSystem
 def combinePure := @privNoisedBoundedMean_DP PureDPSystem
 
 /-

--- a/SampCert.lean
+++ b/SampCert.lean
@@ -27,7 +27,7 @@ def numBins : ℕ+ := 64
 /-
 Bin the infinite type ℕ with clipping
 -/
-def bin (n : ℕ) : Fin numBins :=
+def example_bin (n : ℕ) : Fin numBins :=
   { val := min (Nat.log 2 n) (PNat.natPred numBins),
     isLt := by
       apply min_lt_iff.mpr
@@ -41,7 +41,7 @@ Return an upper bound on the bin value, clipped to 2^(1 + numBins)
 def unbin (n : Fin numBins) : ℕ+ := 2 ^ (1 + n.val)
 
 def combineMeanHistogram : Mechanism ℕ (Option ℚ) :=
-  privMeanHistogram PureDPSystem laplace_pureDPSystem numBins { bin } unbin 1 20 2 1 20
+  privMeanHistogram PureDPSystem laplace_pureDPSystem numBins { bin := example_bin } unbin 1 20 2 1 20
 
 end histogramMeanExample
 

--- a/SampCert/DifferentialPrivacy/Abstract.lean
+++ b/SampCert/DifferentialPrivacy/Abstract.lean
@@ -112,7 +112,7 @@ class DPNoise (dps : DPSystem T) where
   /--
   Adding noise to a query makes it private
   -/
-  noise_prop : ∀ q : List T → ℤ, ∀ Δ εn εd : ℕ+,
+  noise_prop : ∀ q : List T → ℤ, ∀ Δ εn εd : ℕ+, ∀ ε : NNReal,
     sensitivity q Δ →
     noise_priv εn εd ε ->
     dps.prop (noise q Δ εn εd) ε

--- a/SampCert/DifferentialPrivacy/Abstract.lean
+++ b/SampCert/DifferentialPrivacy/Abstract.lean
@@ -52,12 +52,12 @@ class DPSystem (T : Type) where
   /--
   Definition of DP is well-formed: Privacy parameter required to obtain (ε', δ)-approximate DP
   -/
-  of_adp : (δ : NNReal) -> (ε' : NNReal) -> NNReal
+  of_app_dp : (δ : NNReal) -> (ε' : NNReal) -> NNReal
   /--
   For any ε', this definition of DP implies (ε', δ)-approximate-DP for all δ
   -/
   prop_adp [Countable Z] {m : Mechanism T Z} : ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
-    (prop m (of_adp δ ε') -> ApproximateDP m ε' δ)
+    (prop m (of_app_dp δ ε') -> ApproximateDP m ε' δ)
   /--
   DP is monotonic
   -/

--- a/SampCert/DifferentialPrivacy/Abstract.lean
+++ b/SampCert/DifferentialPrivacy/Abstract.lean
@@ -40,29 +40,29 @@ class DPSystem (T : Type) where
   /--
   DP is monotonic
   -/
-  prop_mono {m : Mechanism T Z} {ε₁ ε₂: NNReal} (Hε : ε₁ ≤ ε₂) (H : prop m ε₁) : prop m ε₂
+  prop_mono {m : Mechanism T Z} {ε₁ ε₂: NNReal} :
+    ε₁ ≤ ε₂ -> prop m ε₁ -> prop m ε₂
   /--
   Privacy adaptively composes by addition.
   -/
-  adaptive_compose_prop : {U V : Type} →
-    [MeasurableSpace U] → [Countable U] → [DiscreteMeasurableSpace U] → [Inhabited U] →
-    [MeasurableSpace V] → [Countable V] → [DiscreteMeasurableSpace V] → [Inhabited V] →
-    ∀ m₁ : Mechanism T U, ∀ m₂ : U -> Mechanism T V, ∀ ε₁ ε₂ ε : NNReal,
+  adaptive_compose_prop {U V : Type}
+    [MeasurableSpace U] [Countable U] [DiscreteMeasurableSpace U] [Inhabited U]
+    [MeasurableSpace V] [Countable V] [DiscreteMeasurableSpace V] [Inhabited V]
+    {m₁ : Mechanism T U} {m₂ : U -> Mechanism T V} {ε₁ ε₂ ε : NNReal} :
     prop m₁ ε₁ → (∀ u, prop (m₂ u) ε₂) ->
     ε₁ + ε₂ = ε ->
     prop (privComposeAdaptive m₁ m₂) ε
   /--
   Privacy is invariant under post-processing.
   -/
-  postprocess_prop : {U : Type} → [MeasurableSpace U] → [Countable U] → [DiscreteMeasurableSpace U] → [Inhabited U] → { pp : U → V } →
-    ∀ m : Mechanism T U, ∀ ε : NNReal,
-   prop m ε → prop (privPostProcess m pp) ε
+  postprocess_prop {U : Type} [MeasurableSpace U] [Countable U] [DiscreteMeasurableSpace U] [Inhabited U]
+    { pp : U → V } {m : Mechanism T U} {ε : NNReal} :
+    prop m ε → prop (privPostProcess m pp) ε
   /--
   Constant query is 0-DP
   -/
-  const_prop : {U : Type} → [MeasurableSpace U] → [Countable U] → [DiscreteMeasurableSpace U] -> (u : U) ->
-    ∀ ε : NNReal, ε = (0 : NNReal) -> prop (privConst u) ε
-
+  const_prop {U : Type} [MeasurableSpace U] [Countable U] [DiscreteMeasurableSpace U]  {u : U} {ε : NNReal} :
+    ε = (0 : NNReal) -> prop (privConst u) ε
 
 namespace DPSystem
 
@@ -70,12 +70,13 @@ namespace DPSystem
 Non-adaptive privacy composes by addition.
 -/
 lemma compose_prop {U V : Type} [dps : DPSystem T] [MeasurableSpace U] [Countable U] [DiscreteMeasurableSpace U] [Inhabited U] [MeasurableSpace V] [Countable V] [DiscreteMeasurableSpace V] [Inhabited V] :
-    ∀ m₁ : Mechanism T U, ∀ m₂ : Mechanism T V, ∀ ε₁ ε₂ : NNReal,
-    dps.prop m₁ ε₁ → dps.prop m₂ ε₂ → dps.prop (privCompose m₁ m₂) (ε₁ + ε₂) := by
-  intros m₁ m₂ ε₁ ε₂ p1 p2
+    {m₁ : Mechanism T U} -> {m₂ : Mechanism T V} ->  {ε₁ ε₂ ε : NNReal} ->
+    (ε₁ + ε₂ = ε) ->
+    dps.prop m₁ ε₁ → dps.prop m₂ ε₂ → dps.prop (privCompose m₁ m₂) ε := by
+  intros _ _ _ _ _ _ p1 p2
   unfold privCompose
-  apply adaptive_compose_prop m₁ (fun _ => m₂) ε₁ ε₂ _ p1 (fun _ => p2)
-  rfl
+  apply adaptive_compose_prop p1 (fun _ => p2)
+  trivial
 
 end DPSystem
 
@@ -112,7 +113,7 @@ class DPNoise (dps : DPSystem T) where
   /--
   Adding noise to a query makes it private
   -/
-  noise_prop : ∀ q : List T → ℤ, ∀ Δ εn εd : ℕ+, ∀ ε : NNReal,
+  noise_prop {q : List T → ℤ} {Δ εn εd : ℕ+} {ε : NNReal} :
     noise_priv εn εd ε ->
     sensitivity q Δ →
     dps.prop (noise q Δ εn εd) ε

--- a/SampCert/DifferentialPrivacy/Abstract.lean
+++ b/SampCert/DifferentialPrivacy/Abstract.lean
@@ -113,8 +113,8 @@ class DPNoise (dps : DPSystem T) where
   Adding noise to a query makes it private
   -/
   noise_prop : ∀ q : List T → ℤ, ∀ Δ εn εd : ℕ+, ∀ ε : NNReal,
-    sensitivity q Δ →
     noise_priv εn εd ε ->
+    sensitivity q Δ →
     dps.prop (noise q Δ εn εd) ε
 
 

--- a/SampCert/DifferentialPrivacy/Abstract.lean
+++ b/SampCert/DifferentialPrivacy/Abstract.lean
@@ -56,7 +56,7 @@ class DPSystem (T : Type) where
   /--
   For any ε', this definition of DP implies (ε', δ)-approximate-DP for all δ
   -/
-  prop_adp [Countable Z] {m : Mechanism T Z} : ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
+  prop_adp [DiscProbSpace Z] {m : Mechanism T Z} : ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
     (prop m (of_app_dp δ ε') -> ApproximateDP m ε' δ)
   /--
   DP is monotonic

--- a/SampCert/DifferentialPrivacy/Generic.lean
+++ b/SampCert/DifferentialPrivacy/Generic.lean
@@ -16,48 +16,6 @@ This file defines an abstract system of differentially private operators.
 
 namespace SLang
 
-/-
-A SPMF is a SLang program that is a also proper distribution
--/
-abbrev SPMF.{u} (α : Type u) : Type u := { f : SLang α // HasSum f 1 }
-
-instance : Coe (SPMF α) (SLang α) where
-  coe a := a.1
-
-instance : Coe (SPMF α) (PMF α) where
-  coe a := ⟨ a.1, a.2 ⟩
-
-
-
-@[simp]
-def SPMF_pure (a : α) : SPMF α :=
-  ⟨ probPure a,
-    by
-      have H : PMF.pure a = probPure a := by
-        unfold probPure
-        simp [DFunLike.coe, PMF.instFunLike, PMF.pure]
-      rw [<- H]
-      cases (PMF.pure a)
-      simp [DFunLike.coe, PMF.instFunLike]
-      trivial ⟩
-
-@[simp]
-def SPMF_bind (p : SPMF α) (q : α -> SPMF β) : SPMF β :=
-  ⟨ probBind p (fun x => q x),
-    by
-      have H : (probBind p (fun x => q x)) = (PMF.bind p q) := by
-        unfold probBind
-        simp [DFunLike.coe, PMF.instFunLike, PMF.bind]
-      rw [H]
-      cases (PMF.bind p q)
-      simp [DFunLike.coe, PMF.instFunLike]
-      trivial ⟩
-
-instance : Monad SPMF where
-  pure := SPMF_pure
-  bind := SPMF_bind
-
-
 
 abbrev Query (T U : Type) := List T → U
 

--- a/SampCert/DifferentialPrivacy/Pure/AdaptiveComposition.lean
+++ b/SampCert/DifferentialPrivacy/Pure/AdaptiveComposition.lean
@@ -18,8 +18,10 @@ variable [Hu : Nonempty U]
 namespace SLang
 
 -- Better proof for Pure DP adaptive composition
-theorem PureDP_ComposeAdaptive' (nq1 : List T → PMF U) (nq2 : U -> List T → PMF V) (ε₁ ε₂ : NNReal) (h1 : PureDP nq1 ε₁)  (h2 : ∀ u : U, PureDP (nq2 u) ε₂) :
-  PureDP (privComposeAdaptive nq1 nq2) (ε₁ + ε₂) := by
+theorem PureDP_ComposeAdaptive' (nq1 : List T → PMF U) (nq2 : U -> List T → PMF V) (ε₁ ε₂ ε : NNReal) (h1 : PureDP nq1 ε₁)  (h2 : ∀ u : U, PureDP (nq2 u) ε₂) (Hε : ε₁ + ε₂ = ε ) :
+  PureDP (privComposeAdaptive nq1 nq2) ε := by
+  rw [<- Hε]
+  clear ε Hε
   simp [PureDP] at *
   rw [event_eq_singleton] at *
   simp [DP_singleton] at *

--- a/SampCert/DifferentialPrivacy/Pure/Const.lean
+++ b/SampCert/DifferentialPrivacy/Pure/Const.lean
@@ -32,7 +32,7 @@ theorem privConst_DP_Bound {u : U} : DP (privConst u : Mechanism T U) 0 := by
 /--
 ``privComposeAdaptive`` satisfies zCDP
 -/
-theorem PureDP_privConst : ∀ (u : U),  PureDP (privConst u : Mechanism T U) (0 : NNReal) := by
+theorem PureDP_privConst : ∀ (u : U) (ε : NNReal), (ε = 0) -> PureDP (privConst u : Mechanism T U) ε := by
   simp [PureDP] at *
   apply privConst_DP_Bound
 

--- a/SampCert/DifferentialPrivacy/Pure/DP.lean
+++ b/SampCert/DifferentialPrivacy/Pure/DP.lean
@@ -112,18 +112,20 @@ theorem ApproximateDP_of_DP (m : Mechanism T U) (ε : ℝ) (h : DP m ε) :
   simp
 
 /--
+Pure privacy bound required to obtain (ε, δ)-approximate DP
+-/
+def pure_of_adp (_ : NNReal) (ε : NNReal) : NNReal := ε
+
+/--
 Pure DP is no weaker than approximate DP, up to a loss of parameters
 -/
 lemma pure_ApproximateDP [Countable U] {m : Mechanism T U} :
-    ∃ (degrade : (δ : NNReal) -> (ε' : NNReal) -> NNReal), ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
-     (DP m (degrade δ ε') -> ApproximateDP m ε' δ) := by
-  let degrade (_ : NNReal) (ε' : NNReal) : NNReal := ε'
-  exists degrade
-  intro δ _ ε' HDP
+  ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
+     DP m (pure_of_adp δ ε') -> ApproximateDP m ε' δ := by
+  intro _ _ _ HDP
   rw [ApproximateDP]
   apply ApproximateDP_of_DP
-  have R1 : degrade δ ε' = ε' := by simp
-  rw [R1] at HDP
+  simp [pure_of_adp] at HDP
   trivial
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Pure/Mechanism/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Pure/Mechanism/Properties.lean
@@ -114,12 +114,15 @@ theorem privNoisedQueryPure_DP_bound (query : List T → ℤ) (Δ ε₁ ε₂ : 
           exact (add_lt_add_iff_right 1).mpr A
     · apply exp_pos
 
+def laplace_pureDP_noise_priv (ε₁ ε₂ : ℕ+) (ε : NNReal) : Prop := (ε₁ : NNReal) / ε₂ = ε
 
 /--
 Laplace noising mechanism ``privNoisedQueryPure`` produces a pure ``ε₁/ε₂``-DP mechanism from a Δ-sensitive query.
 -/
-theorem privNoisedQueryPure_DP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (bounded_sensitivity : sensitivity query Δ) :
-  PureDP (privNoisedQueryPure query Δ ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
+theorem privNoisedQueryPure_DP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (ε : NNReal) (bounded_sensitivity : sensitivity query Δ) (HN : laplace_pureDP_noise_priv ε₁ ε₂ ε) :
+    PureDP (privNoisedQueryPure query Δ ε₁ ε₂) ε := by
+  unfold laplace_pureDP_noise_priv at HN
+  rw [<- HN]
   simp [PureDP]
   apply privNoisedQueryPure_DP_bound
   apply bounded_sensitivity

--- a/SampCert/DifferentialPrivacy/Pure/Mechanism/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Pure/Mechanism/Properties.lean
@@ -119,7 +119,7 @@ def laplace_pureDP_noise_priv (ε₁ ε₂ : ℕ+) (ε : NNReal) : Prop := (ε�
 /--
 Laplace noising mechanism ``privNoisedQueryPure`` produces a pure ``ε₁/ε₂``-DP mechanism from a Δ-sensitive query.
 -/
-theorem privNoisedQueryPure_DP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (ε : NNReal) (bounded_sensitivity : sensitivity query Δ) (HN : laplace_pureDP_noise_priv ε₁ ε₂ ε) :
+theorem privNoisedQueryPure_DP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (ε : NNReal) (HN : laplace_pureDP_noise_priv ε₁ ε₂ ε) (bounded_sensitivity : sensitivity query Δ) :
     PureDP (privNoisedQueryPure query Δ ε₁ ε₂) ε := by
   unfold laplace_pureDP_noise_priv at HN
   rw [<- HN]

--- a/SampCert/DifferentialPrivacy/Pure/Postprocessing.lean
+++ b/SampCert/DifferentialPrivacy/Pure/Postprocessing.lean
@@ -29,6 +29,7 @@ lemma privPostProcess_DP_bound {nq : Mechanism T U} {ε : NNReal} (h : PureDP nq
   replace h := h l₁ l₂ neighbours
   simp [privPostProcess]
   apply ENNReal.div_le_of_le_mul
+  simp [SPMF.instFunLike]
   rw [← ENNReal.tsum_mul_left]
   apply tsum_le_tsum _ ENNReal.summable (by aesop)
   intro i

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -23,8 +23,8 @@ Pure ε-DP with noise drawn from the discrete Laplace distribution.
 -/
 instance PureDPSystem : DPSystem T where
   prop := PureDP
-  of_adp := sorry
-  prop_adp := sorry -- pure_ApproximateDP
+  of_adp := pure_of_adp
+  prop_adp := pure_ApproximateDP
   prop_mono := PureDP_mono
   adaptive_compose_prop := PureDP_ComposeAdaptive'
   postprocess_prop := PureDP_PostProcess

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -26,16 +26,13 @@ instance PureDPSystem : DPSystem T where
   of_adp := sorry
   prop_adp := sorry -- pure_ApproximateDP
   prop_mono := PureDP_mono
-  adaptive_compose_prop := sorry -- PureDP_ComposeAdaptive'
+  adaptive_compose_prop := PureDP_ComposeAdaptive'
   postprocess_prop := PureDP_PostProcess
-  const_prop := sorry -- PureDP_privConst
-
+  const_prop := PureDP_privConst
 
 instance laplace_pureDPSystem : DPNoise (@PureDPSystem T) where
   noise := privNoisedQueryPure
-  noise_priv := sorry
-  noise_prop := sorry -- privNoisedQueryPure_DP
-
-
+  noise_priv := laplace_pureDP_noise_priv
+  noise_prop := privNoisedQueryPure_DP
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -23,7 +23,7 @@ Pure ε-DP with noise drawn from the discrete Laplace distribution.
 -/
 instance PureDPSystem : DPSystem T where
   prop := PureDP
-  of_adp := pure_of_adp
+  of_app_dp := pure_of_adp
   prop_adp := pure_ApproximateDP
   prop_mono := PureDP_mono
   adaptive_compose_prop := by

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -26,13 +26,17 @@ instance PureDPSystem : DPSystem T where
   of_adp := pure_of_adp
   prop_adp := pure_ApproximateDP
   prop_mono := PureDP_mono
-  adaptive_compose_prop := PureDP_ComposeAdaptive'
-  postprocess_prop := PureDP_PostProcess
-  const_prop := PureDP_privConst
+  adaptive_compose_prop := by
+    intros; apply PureDP_ComposeAdaptive' <;> trivial
+  postprocess_prop := by
+    intros; apply PureDP_PostProcess; trivial
+  const_prop := by
+    intros; apply PureDP_privConst; trivial
 
 instance laplace_pureDPSystem : DPNoise (@PureDPSystem T) where
   noise := privNoisedQueryPure
   noise_priv := laplace_pureDP_noise_priv
-  noise_prop := privNoisedQueryPure_DP
+  noise_prop := by
+    intros; apply privNoisedQueryPure_DP <;> trivial
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -26,9 +26,9 @@ instance PureDPSystem : DPSystem T where
   of_adp := sorry
   prop_adp := sorry -- pure_ApproximateDP
   prop_mono := PureDP_mono
-  adaptive_compose_prop := PureDP_ComposeAdaptive'
+  adaptive_compose_prop := sorry -- PureDP_ComposeAdaptive'
   postprocess_prop := PureDP_PostProcess
-  const_prop := PureDP_privConst
+  const_prop := sorry -- PureDP_privConst
 
 
 instance laplace_pureDPSystem : DPNoise (@PureDPSystem T) where

--- a/SampCert/DifferentialPrivacy/Pure/System.lean
+++ b/SampCert/DifferentialPrivacy/Pure/System.lean
@@ -21,14 +21,21 @@ variable { T : Type }
 /--
 Pure ε-DP with noise drawn from the discrete Laplace distribution.
 -/
-noncomputable instance PureDPSystem : DPSystem T where
+instance PureDPSystem : DPSystem T where
   prop := PureDP
-  prop_adp := pure_ApproximateDP
+  of_adp := sorry
+  prop_adp := sorry -- pure_ApproximateDP
   prop_mono := PureDP_mono
-  noise := privNoisedQueryPure
-  noise_prop := privNoisedQueryPure_DP
   adaptive_compose_prop := PureDP_ComposeAdaptive'
   postprocess_prop := PureDP_PostProcess
   const_prop := PureDP_privConst
+
+
+instance laplace_pureDPSystem : DPNoise (@PureDPSystem T) where
+  noise := privNoisedQueryPure
+  noise_priv := sorry
+  noise_prop := sorry -- privNoisedQueryPure_DP
+
+
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Code.lean
@@ -13,8 +13,6 @@ import SampCert.DifferentialPrivacy.Queries.BoundedSum.Code
 This file defines a differentially private bounded mean query.
 -/
 
-noncomputable section
-
 namespace SLang
 
 variable [dps : DPSystem ℕ]
@@ -23,7 +21,7 @@ variable [dpn : DPNoise dps]
 /--
 Compute a noised mean using a noised sum and noised count.
 -/
-def privNoisedBoundedMean (U : ℕ+) (ε₁ ε₂ : ℕ+) (l : List ℕ) : PMF ℚ := do
+def privNoisedBoundedMean (U : ℕ+) (ε₁ ε₂ : ℕ+) (l : List ℕ) : SPMF ℚ := do
   let S ← privNoisedBoundedSum U ε₁ (2 * ε₂) l
   let C ← privNoisedCount ε₁ (2 * ε₂) l
   return S / C

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Code.lean
@@ -18,6 +18,7 @@ noncomputable section
 namespace SLang
 
 variable [dps : DPSystem ℕ]
+variable [dpn : DPNoise dps]
 
 /--
 Compute a noised mean using a noised sum and noised count.

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
@@ -39,6 +39,7 @@ theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) :
   rw [budget_split]
   apply dps.compose_prop
   · apply privNoisedBoundedSum_DP
-  · apply privNoisedCount_DP
+  · sorry
+    -- apply privNoisedCount_DP
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
@@ -34,12 +34,13 @@ DP bound for noised mean.
 theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) :
   dps.prop (privNoisedBoundedMean U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
   unfold privNoisedBoundedMean
-  rw [bind_bind_indep]
-  apply dps.postprocess_prop
-  rw [budget_split]
-  apply dps.compose_prop
-  · apply privNoisedBoundedSum_DP
-  · sorry
-    -- apply privNoisedCount_DP
+  sorry
+  -- rw [bind_bind_indep]
+  -- apply dps.postprocess_prop
+  -- rw [budget_split]
+  -- apply dps.compose_prop
+  -- · apply privNoisedBoundedSum_DP
+  -- · sorry
+  --   -- apply privNoisedCount_DP
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
@@ -31,16 +31,23 @@ lemma budget_split (ε₁ ε₂ : ℕ+) :
 /--
 DP bound for noised mean.
 -/
-theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) :
+theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+)
+  (HP_half : dpn.noise_priv ε₁ (2 * ε₂) (ε₁ / ↑(2 * ε₂))) :
   dps.prop (privNoisedBoundedMean U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
   unfold privNoisedBoundedMean
-  sorry
-  -- rw [bind_bind_indep]
-  -- apply dps.postprocess_prop
-  -- rw [budget_split]
-  -- apply dps.compose_prop
-  -- · apply privNoisedBoundedSum_DP
-  -- · sorry
-  --   -- apply privNoisedCount_DP
+  rw [bind_bind_indep]
+  apply dps.postprocess_prop
+  apply dps.compose_prop ?SC1
+  · apply privNoisedBoundedSum_DP
+    apply HP_half
+  · apply privNoisedCount_DP
+    apply HP_half
+
+  case SC1 =>
+    -- Arithmetic
+    ring_nf
+    rw [div_mul]
+    congr
+    simp
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
@@ -21,6 +21,7 @@ noncomputable section
 namespace SLang
 
 variable [dps : DPSystem ℕ]
+variable [dpn : DPNoise dps]
 
 lemma budget_split (ε₁ ε₂ : ℕ+) :
   (ε₁ : NNReal) / (ε₂ : NNReal) = (ε₁ : NNReal) / ((2 * ε₂) : ℕ+) + (ε₁ : NNReal) / ((2 * ε₂) : ℕ+) := by

--- a/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedMean/Properties.lean
@@ -31,9 +31,9 @@ lemma budget_split (ε₁ ε₂ : ℕ+) :
 /--
 DP bound for noised mean.
 -/
-theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+)
-  (HP_half : dpn.noise_priv ε₁ (2 * ε₂) (ε₁ / ↑(2 * ε₂))) :
-  dps.prop (privNoisedBoundedMean U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
+theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) (ε : NNReal)
+  (HP_half : dpn.noise_priv ε₁ (2 * ε₂) (ε / 2)) :
+  dps.prop (privNoisedBoundedMean U ε₁ ε₂) ε := by
   unfold privNoisedBoundedMean
   rw [bind_bind_indep]
   apply dps.postprocess_prop
@@ -44,10 +44,7 @@ theorem privNoisedBoundedMean_DP (U : ℕ+) (ε₁ ε₂ : ℕ+)
     apply HP_half
 
   case SC1 =>
-    -- Arithmetic
     ring_nf
-    rw [div_mul]
-    congr
-    simp
+    simp [div_mul]
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedSum/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedSum/Code.lean
@@ -14,8 +14,6 @@ import Init.Data.Int.Order
 This file defines a differentially private bounded sum query.
 -/
 
-noncomputable section
-
 namespace SLang
 
 variable [dps : DPSystem ℕ]

--- a/SampCert/DifferentialPrivacy/Queries/BoundedSum/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedSum/Code.lean
@@ -19,6 +19,7 @@ noncomputable section
 namespace SLang
 
 variable [dps : DPSystem ℕ]
+variable [dpn : DPNoise dps]
 
 /--
 Bounded sum query: computes a sum and truncates it at an upper bound.
@@ -30,6 +31,6 @@ def exactBoundedSum (U : ℕ+) (l : List ℕ) : ℤ :=
 Noised bounded sum query obtained by applying the DP noise mechanism to the bounded sum.
 -/
 def privNoisedBoundedSum (U : ℕ+) (ε₁ ε₂ : ℕ+) (l : List ℕ) : PMF ℤ := do
-  dps.noise (exactBoundedSum U) U ε₁ ε₂ l
+  dpn.noise (exactBoundedSum U) U ε₁ ε₂ l
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
@@ -85,8 +85,8 @@ theorem exactBoundedSum_sensitivity (U : ℕ+) : sensitivity (exactBoundedSum U)
 The noised bounded sum satisfies the DP property of the DP system.
 -/
 @[simp]
-theorem privNoisedBoundedSum_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) (HP : dpn.noise_priv ε₁ ε₂ (ε₁ / ε₂)) :
-    dps.prop (privNoisedBoundedSum U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
+theorem privNoisedBoundedSum_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) (ε : NNReal) (HP : dpn.noise_priv ε₁ ε₂ ε) :
+    dps.prop (privNoisedBoundedSum U ε₁ ε₂) ε := by
   apply dpn.noise_prop HP
   apply exactBoundedSum_sensitivity
 

--- a/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
@@ -22,6 +22,7 @@ noncomputable section
 namespace SLang
 
 variable [dps : DPSystem ℕ]
+variable [dpn : DPNoise dps]
 
 /--
 Sensitivity of the bounded sum is equal to the bound.
@@ -86,7 +87,8 @@ The noised bounded sum satisfies the DP property of the DP system.
 @[simp]
 theorem privNoisedBoundedSum_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) :
   dps.prop (privNoisedBoundedSum U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
-  apply dps.noise_prop
-  apply exactBoundedSum_sensitivity
+  sorry
+  -- apply dpn.noise_prop
+  -- apply exactBoundedSum_sensitivity
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/BoundedSum/Properties.lean
@@ -85,10 +85,9 @@ theorem exactBoundedSum_sensitivity (U : ℕ+) : sensitivity (exactBoundedSum U)
 The noised bounded sum satisfies the DP property of the DP system.
 -/
 @[simp]
-theorem privNoisedBoundedSum_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) :
-  dps.prop (privNoisedBoundedSum U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
-  sorry
-  -- apply dpn.noise_prop
-  -- apply exactBoundedSum_sensitivity
+theorem privNoisedBoundedSum_DP (U : ℕ+) (ε₁ ε₂ : ℕ+) (HP : dpn.noise_priv ε₁ ε₂ (ε₁ / ε₂)) :
+    dps.prop (privNoisedBoundedSum U ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
+  apply dpn.noise_prop HP
+  apply exactBoundedSum_sensitivity
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Count/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Count/Code.lean
@@ -17,6 +17,7 @@ namespace SLang
 
 variable {T : Type}
 variable [dps : DPSystem T]
+variable [dpn : DPNoise dps]
 
 /--
 Query to count the size of the input list.
@@ -27,6 +28,6 @@ def exactCount (l : List T) : ℤ := List.length l
 A noised counting mechanism.
 -/
 def privNoisedCount (ε₁ ε₂ : ℕ+) (l : List T) : PMF ℤ := do
-  dps.noise exactCount 1 ε₁ ε₂ l
+  dpn.noise exactCount 1 ε₁ ε₂ l
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Count/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Count/Code.lean
@@ -11,8 +11,6 @@ import SampCert.DifferentialPrivacy.Abstract
 This file defines a differentially private noising of an exact length query.
 -/
 
-noncomputable section
-
 namespace SLang
 
 variable {T : Type}

--- a/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
@@ -45,13 +45,10 @@ theorem exactCount_1_sensitive :
 The noised counting query satisfies DP property
 -/
 @[simp]
-theorem privNoisedCount_DP (ε₁ ε₂ : ℕ+) :
-  dps.prop (privNoisedCount ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
-  apply DPSystem_prop_ext
-  case H =>
-    sorry
-  all_goals sorry
-  -- apply dpn.noise_prop
-  -- apply exactCount_1_sensitive
+theorem privNoisedCount_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (HP : dpn.noise_priv ε₁ ε₂ ε) :
+  dps.prop (privNoisedCount ε₁ ε₂) ε := by
+  unfold privNoisedCount
+  apply (dpn.noise_prop _ _ _ _ _ HP)
+  apply exactCount_1_sensitive
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
@@ -48,7 +48,7 @@ The noised counting query satisfies DP property
 theorem privNoisedCount_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (HP : dpn.noise_priv ε₁ ε₂ ε) :
   dps.prop (privNoisedCount ε₁ ε₂) ε := by
   unfold privNoisedCount
-  apply (dpn.noise_prop _ _ _ _ _ HP)
+  apply dpn.noise_prop HP
   apply exactCount_1_sensitive
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Count/Properties.lean
@@ -21,6 +21,7 @@ namespace SLang
 
 variable {T : Type}
 variable [dps : DPSystem T]
+variable [dpn : DPNoise dps]
 
 /--
 The counting query is 1-sensitive
@@ -46,7 +47,11 @@ The noised counting query satisfies DP property
 @[simp]
 theorem privNoisedCount_DP (ε₁ ε₂ : ℕ+) :
   dps.prop (privNoisedCount ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
-  apply dps.noise_prop
-  apply exactCount_1_sensitive
+  apply DPSystem_prop_ext
+  case H =>
+    sorry
+  all_goals sorry
+  -- apply dpn.noise_prop
+  -- apply exactCount_1_sensitive
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Code.lean
@@ -87,6 +87,7 @@ instance : DiscreteMeasurableSpace (Histogram T numBins B) where
 namespace SLang
 
 variable [dps : DPSystem T]
+variable [dpn : DPNoise dps]
 
 /--
 Compute the exact number of elements inside a histogram bin
@@ -98,7 +99,7 @@ def exactBinCount (b : Fin numBins) (l : List T) : ℤ :=
 Compute a noised count of the number of list elements inside a particular histogram bin
 -/
 def privNoisedBinCount (ε₁ ε₂ : ℕ+) (b : Fin numBins) : Mechanism T ℤ :=
-  (dps.noise (exactBinCount numBins B b) 1 ε₁ (ε₂ * numBins))
+  (dpn.noise (exactBinCount numBins B b) 1 ε₁ (ε₂ * numBins))
 
 /--
 Modify a count inside a Histogram

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Code.lean
@@ -24,8 +24,6 @@ structure Bins (T : Type) (num_bins : ℕ) where
 ## Private Histograms
 -/
 
-noncomputable section
-
 variable (numBins : ℕ+)
 
 def predBins : ℕ := numBins.natPred

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
@@ -76,19 +76,23 @@ lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (n : ℕ) (Hn : n < numBins
   induction n
   · unfold privNoisedHistogramAux
     simp only [Nat.cast_zero, succ_eq_add_one, zero_add, Nat.cast_one, Nat.cast_mul, one_mul]
-    refine DPSystem.postprocess_prop
-             (privCompose (privNoisedBinCount numBins B ε₁ ε₂ 0) (privConst (emptyHistogram numBins B)))
-             (↑↑ε₁ / ↑↑(ε₂ * numBins)) ?G1
-    apply (DPSystem_prop_ext _ ?HEq ?Hdp)
-    case Hdp =>
-      apply (DPSystem.compose_prop
-              (privNoisedBinCount numBins B ε₁ ε₂ 0)
-              (privConst (emptyHistogram numBins B))
-              (↑↑ε₁ / ↑↑(ε₂ * numBins))
-              0
-              (privNoisedBinCount_DP numBins B ε₁ ε₂ 0)
-              (DPSystem.const_prop (emptyHistogram numBins B)))
-    case HEq => simp only [PNat.mul_coe, Nat.cast_mul, add_zero]
+    sorry
+    -- refine DPSystem.postprocess_prop
+    --          (privCompose (privNoisedBinCount numBins B ε₁ ε₂ 0) (privConst (emptyHistogram numBins B)))
+    --          (↑↑ε₁ / ↑↑(ε₂ * numBins)) ?G1
+    -- apply (DPSystem_prop_ext _ ?HEq ?Hdp)
+    -- case Hdp =>
+    --   sorry
+    --   -- apply (DPSystem.compose_prop
+    --   --         (privNoisedBinCount numBins B ε₁ ε₂ 0)
+    --   --         (privConst (emptyHistogram numBins B))
+    --   --         (↑↑ε₁ / ↑↑(ε₂ * numBins))
+    --   --         0
+    --   --         (privNoisedBinCount_DP numBins B ε₁ ε₂ 0)
+    --   --         (DPSystem.const_prop (emptyHistogram numBins B)))
+    -- case HEq =>
+    --   sorry
+    --   -- simp only [PNat.mul_coe, Nat.cast_mul, add_zero]
   · rename_i n IH
     unfold privNoisedHistogramAux
     simp only []

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
@@ -27,9 +27,6 @@ variable [HT : Inhabited T]
 variable (numBins : ℕ+)
 variable (B : Bins T numBins)
 
--- def exactBinCount (b : Fin num_bins) (l : List T) : ℤ :=
---   List.length (List.filter (fun v => B.bin v = b) l)
-
 /-
 exactBinCount is 1-sensitive
 -/
@@ -59,108 +56,63 @@ theorem exactBinCount_sensitivity (b : Fin numBins) : sensitivity (exactBinCount
 /--
 DP bound for a noised bin count
 -/
-lemma privNoisedBinCount_DP (ε₁ ε₂ : ℕ+) (b : Fin numBins) :
-  dps.prop (privNoisedBinCount numBins B ε₁ ε₂ b) (ε₁ / ((ε₂ * numBins : PNat))) := by
+lemma privNoisedBinCount_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (b : Fin numBins)
+  (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+  dps.prop (privNoisedBinCount numBins B ε₁ ε₂ b) (ε / numBins) := by
   unfold privNoisedBinCount
-  sorry
-  -- apply dpn.noise_prop
-  -- apply exactBinCount_sensitivity
+  apply dpn.noise_prop HN_bin
+  apply exactBinCount_sensitivity
 
--- MARKUSDE: Looking at this proof it is clear that we need better tactic support for the abstract DP operators
--- MARKUSDE: - Lemmas with equality side conditions for the privacy cost
 /--
 DP bound for intermediate steps in the histogram calculation.
 -/
-lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (n : ℕ) (Hn : n < numBins) :
-  dps.prop (privNoisedHistogramAux numBins B ε₁ ε₂ n Hn) (n.succ * (ε₁ / (ε₂ * numBins : PNat))) := by
+lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (n : ℕ) (Hn : n < numBins)
+  (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+  dps.prop (privNoisedHistogramAux numBins B ε₁ ε₂ n Hn) (n.succ * (ε / numBins)) := by
   induction n
   · unfold privNoisedHistogramAux
     simp only [Nat.cast_zero, succ_eq_add_one, zero_add, Nat.cast_one, Nat.cast_mul, one_mul]
-    sorry
-    -- refine DPSystem.postprocess_prop
-    --          (privCompose (privNoisedBinCount numBins B ε₁ ε₂ 0) (privConst (emptyHistogram numBins B)))
-    --          (↑↑ε₁ / ↑↑(ε₂ * numBins)) ?G1
-    -- apply (DPSystem_prop_ext _ ?HEq ?Hdp)
-    -- case Hdp =>
-    --   sorry
-    --   -- apply (DPSystem.compose_prop
-    --   --         (privNoisedBinCount numBins B ε₁ ε₂ 0)
-    --   --         (privConst (emptyHistogram numBins B))
-    --   --         (↑↑ε₁ / ↑↑(ε₂ * numBins))
-    --   --         0
-    --   --         (privNoisedBinCount_DP numBins B ε₁ ε₂ 0)
-    --   --         (DPSystem.const_prop (emptyHistogram numBins B)))
-    -- case HEq =>
-    --   sorry
-    --   -- simp only [PNat.mul_coe, Nat.cast_mul, add_zero]
+    apply DPSystem.postprocess_prop
+    apply DPSystem.compose_prop ?SC1
+    · apply privNoisedBinCount_DP
+      apply HN_bin
+    · apply DPSystem.const_prop
+      rfl
+    case SC1 => simp only [add_zero]
   · rename_i n IH
     unfold privNoisedHistogramAux
     simp only []
-    sorry
-    -- refine DPSystem.postprocess_prop
-    --   (privCompose (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
-    --   (privNoisedHistogramAux numBins B ε₁ ε₂ n (privNoisedHistogramAux.proof_2 numBins n Hn)))
-    --   (↑(n + 1).succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?succ.a
-    -- apply (@DPSystem_prop_ext _ _ _ (?C1 + ?C2) _ _ ?HCeq ?Hdp)
-    -- case Hdp =>
-    --   refine
-    --     (DPSystem.compose_prop
-    --       (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
-    --       (privNoisedHistogramAux numBins B ε₁ ε₂ n _) (↑↑ε₁ / ↑↑(ε₂ * numBins)) (↑n.succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?X ?Y)
-    --   case X => exact privNoisedBinCount_DP numBins B ε₁ ε₂ ↑(n + 1)
-    --   case Y => apply IH
-    -- generalize (ε₁.val.cast / (ε₂ * numBins).val.cast : NNReal) = A
-    -- conv =>
-    --   enter [1, 1]
-    --   rw [Eq.symm (one_mul A)]
-    -- rw [<- add_mul]
-    -- congr
-    -- simp only [succ_eq_add_one, Nat.cast_add, Nat.cast_one]
-    -- exact AddCommMagma.add_comm (OfNat.ofNat 1) (n.cast + OfNat.ofNat 1)
+    apply DPSystem.postprocess_prop
+    apply DPSystem.compose_prop ?SC1
+    · apply privNoisedBinCount_DP
+      apply HN_bin
+    · apply IH
+    case SC1 =>
+      simp
+      ring_nf
 
 /--
 DP bound for a noised histogram
 -/
-lemma privNoisedHistogram_DP (ε₁ ε₂ : ℕ+) :
-  dps.prop (privNoisedHistogram numBins B ε₁ ε₂) (ε₁ / ε₂) := by
+lemma privNoisedHistogram_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+  dps.prop (privNoisedHistogram numBins B ε₁ ε₂) ε := by
   unfold privNoisedHistogram
   apply (DPSystem_prop_ext _ ?HEq ?Hdp)
-  case Hdp => apply privNoisedHistogramAux_DP
+  case Hdp =>
+    apply privNoisedHistogramAux_DP
+    apply HN_bin
   case HEq =>
-    simp
-    rw [division_def]
-    rw [division_def]
-    rw [mul_inv]
-    conv =>
-      enter [1, 2]
-      rw [<- mul_assoc]
-      rw [mul_comm]
-    generalize (ε₁.val.cast * ε₂.val.cast⁻¹ : NNReal)  = A
-    rw [<- mul_assoc]
-    conv =>
-      enter [2]
-      rw [Eq.symm (one_mul A)]
-    congr
-    unfold predBins
-    cases numBins
-    rename_i n' Hn'
-    simp only [PNat.natPred_eq_pred, pred_eq_sub_one, cast_tsub, Nat.cast_one, PNat.mk_coe]
-    rw [tsub_add_eq_max]
-    rw [max_eq_left (one_le_cast.mpr Hn')]
-    apply mul_inv_cancel
-    intro HK
-    simp_all
-    rw [HK] at Hn'
-    cases Hn'
-
+    simp [predBins]
+    simp [mul_div_left_comm]
 
 /--
 DP bound for the thresholding maximum
 -/
-lemma privMaxBinAboveThreshold_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) :
-  dps.prop (privMaxBinAboveThreshold numBins B ε₁ ε₂ τ) (ε₁ / ε₂) := by
-  rw [privMaxBinAboveThreshold]
+lemma privMaxBinAboveThreshold_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (τ : ℤ) (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+  dps.prop (privMaxBinAboveThreshold numBins B ε₁ ε₂ τ) ε := by
+  unfold privMaxBinAboveThreshold
   apply dps.postprocess_prop
   apply privNoisedHistogram_DP
+  apply HN_bin
 
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
@@ -21,6 +21,7 @@ namespace SLang
 
 variable {T : Type}
 variable [dps : DPSystem T]
+variable [dpn : DPNoise dps]
 variable [HT : Inhabited T]
 
 variable (numBins : ℕ+)
@@ -61,8 +62,9 @@ DP bound for a noised bin count
 lemma privNoisedBinCount_DP (ε₁ ε₂ : ℕ+) (b : Fin numBins) :
   dps.prop (privNoisedBinCount numBins B ε₁ ε₂ b) (ε₁ / ((ε₂ * numBins : PNat))) := by
   unfold privNoisedBinCount
-  apply dps.noise_prop
-  apply exactBinCount_sensitivity
+  sorry
+  -- apply dpn.noise_prop
+  -- apply exactBinCount_sensitivity
 
 -- MARKUSDE: Looking at this proof it is clear that we need better tactic support for the abstract DP operators
 -- MARKUSDE: - Lemmas with equality side conditions for the privacy cost

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
@@ -96,26 +96,27 @@ lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (n : ℕ) (Hn : n < numBins
   · rename_i n IH
     unfold privNoisedHistogramAux
     simp only []
-    refine DPSystem.postprocess_prop
-      (privCompose (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
-      (privNoisedHistogramAux numBins B ε₁ ε₂ n (privNoisedHistogramAux.proof_2 numBins n Hn)))
-      (↑(n + 1).succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?succ.a
-    apply (@DPSystem_prop_ext _ _ _ (?C1 + ?C2) _ _ ?HCeq ?Hdp)
-    case Hdp =>
-      refine
-        (DPSystem.compose_prop
-          (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
-          (privNoisedHistogramAux numBins B ε₁ ε₂ n _) (↑↑ε₁ / ↑↑(ε₂ * numBins)) (↑n.succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?X ?Y)
-      case X => exact privNoisedBinCount_DP numBins B ε₁ ε₂ ↑(n + 1)
-      case Y => apply IH
-    generalize (ε₁.val.cast / (ε₂ * numBins).val.cast : NNReal) = A
-    conv =>
-      enter [1, 1]
-      rw [Eq.symm (one_mul A)]
-    rw [<- add_mul]
-    congr
-    simp only [succ_eq_add_one, Nat.cast_add, Nat.cast_one]
-    exact AddCommMagma.add_comm (OfNat.ofNat 1) (n.cast + OfNat.ofNat 1)
+    sorry
+    -- refine DPSystem.postprocess_prop
+    --   (privCompose (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
+    --   (privNoisedHistogramAux numBins B ε₁ ε₂ n (privNoisedHistogramAux.proof_2 numBins n Hn)))
+    --   (↑(n + 1).succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?succ.a
+    -- apply (@DPSystem_prop_ext _ _ _ (?C1 + ?C2) _ _ ?HCeq ?Hdp)
+    -- case Hdp =>
+    --   refine
+    --     (DPSystem.compose_prop
+    --       (privNoisedBinCount numBins B ε₁ ε₂ ↑(n + 1))
+    --       (privNoisedHistogramAux numBins B ε₁ ε₂ n _) (↑↑ε₁ / ↑↑(ε₂ * numBins)) (↑n.succ * (↑↑ε₁ / ↑↑(ε₂ * numBins))) ?X ?Y)
+    --   case X => exact privNoisedBinCount_DP numBins B ε₁ ε₂ ↑(n + 1)
+    --   case Y => apply IH
+    -- generalize (ε₁.val.cast / (ε₂ * numBins).val.cast : NNReal) = A
+    -- conv =>
+    --   enter [1, 1]
+    --   rw [Eq.symm (one_mul A)]
+    -- rw [<- add_mul]
+    -- congr
+    -- simp only [succ_eq_add_one, Nat.cast_add, Nat.cast_one]
+    -- exact AddCommMagma.add_comm (OfNat.ofNat 1) (n.cast + OfNat.ofNat 1)
 
 /--
 DP bound for a noised histogram

--- a/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/Histogram/Properties.lean
@@ -27,6 +27,8 @@ variable [HT : Inhabited T]
 variable (numBins : ℕ+)
 variable (B : Bins T numBins)
 
+variable (ε₁ ε₂ : ℕ+) (ε : NNReal) (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins))
+
 /-
 exactBinCount is 1-sensitive
 -/
@@ -40,8 +42,7 @@ theorem exactBinCount_sensitivity (b : Fin numBins) : sensitivity (exactBinCount
 /--
 DP bound for a noised bin count
 -/
-lemma privNoisedBinCount_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (b : Fin numBins)
-  (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+lemma privNoisedBinCount_DP  (b : Fin numBins) :
   dps.prop (privNoisedBinCount numBins B ε₁ ε₂ b) (ε / numBins) := by
   unfold privNoisedBinCount
   apply dpn.noise_prop HN_bin
@@ -50,8 +51,7 @@ lemma privNoisedBinCount_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (b : Fin numBins)
 /--
 DP bound for intermediate steps in the histogram calculation.
 -/
-lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (n : ℕ) (Hn : n < numBins)
-  (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+lemma privNoisedHistogramAux_DP (n : ℕ) (Hn : n < numBins) :
   dps.prop (privNoisedHistogramAux numBins B ε₁ ε₂ n Hn) (n.succ * (ε / numBins)) := by
   induction n
   · unfold privNoisedHistogramAux
@@ -71,7 +71,7 @@ lemma privNoisedHistogramAux_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (n : ℕ) (Hn
 /--
 DP bound for a noised histogram
 -/
-lemma privNoisedHistogram_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+lemma privNoisedHistogram_DP :
   dps.prop (privNoisedHistogram numBins B ε₁ ε₂) ε := by
   unfold privNoisedHistogram
   apply (DPSystem_prop_ext _ ?HEq ?Hdp)
@@ -81,7 +81,7 @@ lemma privNoisedHistogram_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (HN_bin : dpn.no
 /--
 DP bound for the thresholding maximum
 -/
-lemma privMaxBinAboveThreshold_DP (ε₁ ε₂ : ℕ+) (ε : NNReal) (τ : ℤ) (HN_bin : dpn.noise_priv ε₁ (ε₂ * numBins) (ε / numBins)) :
+lemma privMaxBinAboveThreshold_DP (τ : ℤ) :
   dps.prop (privMaxBinAboveThreshold numBins B ε₁ ε₂ τ) ε := by
   unfold privMaxBinAboveThreshold
   apply dps.postprocess_prop

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Code.lean
@@ -23,6 +23,7 @@ Implementation for
 noncomputable section
 
 variable (dps : SLang.DPSystem ℕ)
+variable (dpn : SLang.DPNoise dps)
 variable (numBins : ℕ+)
 variable (B : Bins ℕ numBins)
 
@@ -44,7 +45,7 @@ and the bounded mean with (ε₃/ε₄)-DP.
 def privMeanHistogram (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) : Mechanism ℕ (Option ℚ) :=
   privPostProcess
     (privComposeAdaptive
-      (@privMaxBinAboveThreshold numBins _ B dps ε₁ ε₂ τ)
+      (@privMaxBinAboveThreshold numBins _ B dps dpn ε₁ ε₂ τ)
       (fun opt_max =>
         match opt_max with
         | none => privConst none

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Code.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Code.lean
@@ -20,8 +20,6 @@ Implementation for
 ## Compute the mean using a histogram to compute the noisy max
 -/
 
-noncomputable section
-
 variable (dps : SLang.DPSystem ℕ)
 variable (dpn : SLang.DPNoise dps)
 variable (numBins : ℕ+)

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
@@ -73,9 +73,10 @@ lemma privMeanHistogram_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) 
     -- apply dps.prop_mono ?G1 ?G2
     -- case G2 => apply dps.const_prop
     -- simp only [_root_.zero_le]
-  · rename_i mx
-    simp only
-    apply dps.postprocess_prop
-    apply privNoisedBoundedMean_DP
+  · sorry
+    -- rename_i mx
+    -- simp only
+    -- apply dps.postprocess_prop
+    -- apply privNoisedBoundedMean_DP
   rfl
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
@@ -22,6 +22,7 @@ noncomputable section
 namespace SLang
 
 variable (dps : DPSystem ℕ)
+variable (dpn : DPNoise dps)
 variable (numBins : ℕ+)
 variable (B : Bins ℕ numBins)
 variable (unbin : Fin numBins -> ℕ+)
@@ -60,7 +61,7 @@ instance : DiscreteMeasurableSpace (Option (Fin ↑numBins)) where
 DP bound for the adaptive mean
 -/
 lemma privMeanHistogram_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) :
-    dps.prop (privMeanHistogram dps numBins B unbin ε₁ ε₂ τ ε₃ ε₄) (ε₁/ε₂ + ε₃/ε₄) := by
+    dps.prop (privMeanHistogram dps dpn numBins B unbin ε₁ ε₂ τ ε₃ ε₄) (ε₁/ε₂ + ε₃/ε₄) := by
   rw [privMeanHistogram]
   apply dps.postprocess_prop
   apply dps.adaptive_compose_prop

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
@@ -57,26 +57,28 @@ instance : DiscreteMeasurableSpace (Option (Fin ↑numBins)) where
   forall_measurableSet := by simp only [MeasurableSpace.measurableSet_top, implies_true]
 
 
-/-
+/--
 DP bound for the adaptive mean
 -/
-lemma privMeanHistogram_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) :
-    dps.prop (privMeanHistogram dps dpn numBins B unbin ε₁ ε₂ τ ε₃ ε₄) (ε₁/ε₂ + ε₃/ε₄) := by
+lemma privMeanHistogram_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) (εA εB : NNReal)
+      (HN_A : dpn.noise_priv ε₁ (ε₂ * numBins) (εA / numBins))
+      (HN_B : dpn.noise_priv ε₃ (2 * ε₄) (εB / 2)):
+    dps.prop (privMeanHistogram dps dpn numBins B unbin ε₁ ε₂ τ ε₃ ε₄) (εA + εB) := by
   rw [privMeanHistogram]
   apply dps.postprocess_prop
   apply dps.adaptive_compose_prop
   · apply privMaxBinAboveThreshold_DP
-  intro u
-  cases u
-  · simp only
-    sorry
-    -- apply dps.prop_mono ?G1 ?G2
-    -- case G2 => apply dps.const_prop
-    -- simp only [_root_.zero_le]
-  · sorry
-    -- rename_i mx
-    -- simp only
-    -- apply dps.postprocess_prop
-    -- apply privNoisedBoundedMean_DP
+    apply HN_A
+  · intro u
+    cases u
+    · simp only []
+      apply (@DPSystem.prop_mono _ _ _ _ 0 εB _)
+      · apply dps.const_prop
+        rfl
+      · apply _root_.zero_le
+    · simp only []
+      apply dps.postprocess_prop
+      apply privNoisedBoundedMean_DP
+      apply HN_B
   rfl
 end SLang

--- a/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
+++ b/SampCert/DifferentialPrivacy/Queries/HistogramMean/Properties.lean
@@ -69,11 +69,13 @@ lemma privMeanHistogram_DP (ε₁ ε₂ : ℕ+) (τ : ℤ) (ε₃ ε₄ : ℕ+) 
   intro u
   cases u
   · simp only
-    apply dps.prop_mono ?G1 ?G2
-    case G2 => apply dps.const_prop
-    simp only [_root_.zero_le]
+    sorry
+    -- apply dps.prop_mono ?G1 ?G2
+    -- case G2 => apply dps.const_prop
+    -- simp only [_root_.zero_le]
   · rename_i mx
     simp only
     apply dps.postprocess_prop
     apply privNoisedBoundedMean_DP
+  rfl
 end SLang

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/AdaptiveComposition.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/AdaptiveComposition.lean
@@ -131,50 +131,14 @@ theorem privComposeAdaptive_zCDPBound {nq1 : List T → PMF U} {nq2 : U -> List 
   zCDPBound (privComposeAdaptive nq1 nq2) (ε₁ + ε₂) := by
   rw [zCDPBound]
   intro α Hα l₁ l₂ Hneighbours
-  -- This step is loose
-  apply (@LE.le.trans _ _ _ (ENNReal.ofReal (1/2 * (ε₁)^2 * α + 1/2 * (ε₂)^2 * α : ℝ)) _ _ ?case_sq)
-  case case_sq =>
-    apply ofReal_le_ofReal
-    -- Binomial bound
-    rw [add_sq]
-    rw [<- right_distrib]
-    apply (mul_le_mul_of_nonneg_right _ ?goal1)
-    case goal1 => linarith
-    rw [<- left_distrib]
-    apply (mul_le_mul_of_nonneg_left _ ?goal1)
-    case goal1 => linarith
-    apply add_le_add_right
-    have hrw :  ε₁ ^ 2 = ε₁ ^ 2 + 0 := by linarith
-    conv =>
-      lhs
-      rw [hrw]
-    clear hrw
-    apply add_le_add_left
-    refine mul_nonneg ?bc.bc.ha Hε₂
-    refine mul_nonneg ?G Hε₁
-    simp
   -- Rewrite the upper bounds in terms of Renyi divergences of nq1/nq2
   rw [zCDPBound] at h1
   -- have marginal_ub := h1 α Hα l₁ l₂ Hneighbours
-  have conditional_ub : (⨆ (u : U),  RenyiDivergence (nq2 u l₁) (nq2 u l₂) α ≤ ENNReal.ofReal (1 / 2 * ε₂ ^ 2 * α)) :=
-    ciSup_le fun x => h2 x α Hα l₁ l₂ Hneighbours
+  have conditional_ub : (⨆ (u : U),  RenyiDivergence (nq2 u l₁) (nq2 u l₂) α) ≤ ENNReal.ofReal ε₂  := -- ENNReal.ofReal (1 / 2 * ε₂ ^ 2 * α)) :=
+    iSup_le fun i => h2 i α Hα l₁ l₂ Hneighbours
   apply (@LE.le.trans _ _ _ (RenyiDivergence (nq1 l₁) (nq1 l₂) α + ⨆ (u : U), RenyiDivergence (nq2 u l₁) (nq2 u l₂) α) _ _ ?case_alg)
   case case_alg =>
-    rw [ENNReal.ofReal_add ?G1 ?G2]
-    case G1 =>
-      simp
-      apply mul_nonneg
-      · apply mul_nonneg
-        · simp
-        · exact sq_nonneg ε₁
-      · linarith
-    case G2 =>
-      simp
-      apply mul_nonneg
-      · apply mul_nonneg
-        · simp
-        · exact sq_nonneg ε₂
-      · linarith
+    rw [ENNReal.ofReal_add Hε₁ Hε₂]
     exact _root_.add_le_add (h1 α Hα l₁ l₂ Hneighbours) conditional_ub
   exact privComposeAdaptive_renyi_bound Hα Hneighbours HAC1 HAC2
 

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/AdaptiveComposition.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/AdaptiveComposition.lean
@@ -134,11 +134,18 @@ theorem privComposeAdaptive_zCDPBound {nq1 : List T → PMF U} {nq2 : U -> List 
   -- Rewrite the upper bounds in terms of Renyi divergences of nq1/nq2
   rw [zCDPBound] at h1
   -- have marginal_ub := h1 α Hα l₁ l₂ Hneighbours
-  have conditional_ub : (⨆ (u : U),  RenyiDivergence (nq2 u l₁) (nq2 u l₂) α) ≤ ENNReal.ofReal ε₂  := -- ENNReal.ofReal (1 / 2 * ε₂ ^ 2 * α)) :=
-    iSup_le fun i => h2 i α Hα l₁ l₂ Hneighbours
+  have conditional_ub : (⨆ (u : U),  RenyiDivergence (nq2 u l₁) (nq2 u l₂) α) ≤ ENNReal.ofReal (ε₂ * α) :=
+    by exact iSup_le fun i => h2 i α Hα l₁ l₂ Hneighbours
   apply (@LE.le.trans _ _ _ (RenyiDivergence (nq1 l₁) (nq1 l₂) α + ⨆ (u : U), RenyiDivergence (nq2 u l₁) (nq2 u l₂) α) _ _ ?case_alg)
   case case_alg =>
-    rw [ENNReal.ofReal_add Hε₁ Hε₂]
+    rw [add_mul]
+    rw [ENNReal.ofReal_add ?G1 ?G2]
+    case G1 =>
+      apply Right.mul_nonneg Hε₁
+      linarith
+    case G2 =>
+      apply Right.mul_nonneg Hε₂
+      linarith
     exact _root_.add_le_add (h1 α Hα l₁ l₂ Hneighbours) conditional_ub
   exact privComposeAdaptive_renyi_bound Hα Hneighbours HAC1 HAC2
 

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -44,7 +44,7 @@ satisfying this bound are ``ε``-DP).
 -/
 def zCDPBound (q : List T → PMF U) (ε : ℝ) : Prop :=
   ∀ α : ℝ, 1 < α → ∀ l₁ l₂ : List T, Neighbour l₁ l₂ →
-  RenyiDivergence (q l₁) (q l₂) α ≤ ENNReal.ofReal ε
+  RenyiDivergence (q l₁) (q l₂) α ≤ ENNReal.ofReal (ε * α)
 
 /--
 All neighbouring queries are absolutely continuous

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -665,31 +665,82 @@ theorem ApproximateDP_of_zCDP [Countable U] (m : Mechanism T U)
     case G2 => exact Hm l₁ l₂ HN
     simp
 
+
+def D (δ : NNReal) : Real := (2 * Real.log (1 / δ)) ^ ((1 : ℝ) / (2 : ℝ))
+
+def ε (ε' : NNReal) (δ : NNReal) : NNReal :=
+  Real.toNNReal ((-2 * D δ + .sqrt ((2 * D δ) ^ 2 + 8 * ε')) / 2) ^ ((1 : ℝ) / (2 : ℝ))
+
+lemma eqε (ε' δ : NNReal) (H : δ < 1) : ε' = ((ε ε' δ)^2) / (2 : NNReal) + ε ε' δ * D δ := by
+  sorry
+
+/--
+Pure privacy bound required to obtain (ε, δ)-approximate DP
+-/
+def zCDP_of_adp (δ : NNReal) (ε' : NNReal) : NNReal := (1/2) * ((ε ε' δ)^2)
+  -- (√(2 * Real.log (1/δ) + 2 * ε) - √(2 * Real.log (1/δ))).toNNReal
+
 /--
 zCDP is no weaker than approximate DP, up to a loss of parameters.
 -/
 lemma zCDP_ApproximateDP [Countable U] {m : Mechanism T U} :
-    ∃ (degrade : (δ : NNReal) -> (ε' : NNReal) -> NNReal), ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
-     (zCDP m (degrade δ ((1/2) * ε'^2)) -> ApproximateDP m ε' δ) := by
-  let degrade (δ : NNReal) (ε' : NNReal) : NNReal :=
-    (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal
-  have HDdegrade δ ε' : degrade δ ε' = (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal := by rfl
-  exists degrade
-  intro δ Hδ ε' ⟨ HN , HB ⟩
-
+      ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
+     (zCDP m (zCDP_of_adp δ ε') -> ApproximateDP m ε' δ) := by
+  intro δ Hδ ε' H
   cases Classical.em (1 ≤ δ)
   · rename_i Hδ1
     exact ApproximateDP_gt1 m (↑ε') Hδ1
-
   rename_i Hδ1
-  rw [ApproximateDP]
+  simp at Hδ1
+  unfold ApproximateDP
+
+  unfold zCDP_of_adp at H
+  rcases H with ⟨ H1, H2 ⟩
+  have X := ApproximateDP_of_zCDP m (ε ε' δ) ?G1 H2 H1 δ Hδ
+  case G1 => exact NNReal.zero_le_coe
+  rw [eqε ε' δ Hδ1]
+  -- We have this, basically.
+  unfold D
+  simp_all
 
 
-  have R := ApproximateDP_of_zCDP m (degrade δ ε') (by simp) ?G1 HN δ Hδ
-  case G1 =>
-    -- this proof has to be redone
-    sorry
-  sorry
+
+  -- #check ApproximateDP_of_zCDP
+  -- have X := ApproximateDP_of_zCDP m ((2 * zCDP_of_adp δ ε') ^ ((1 : Real) / 2)) ?G1 ?G2 ?G3 δ Hδ
+  -- case G1 =>
+  --   apply Real.rpow_nonneg
+  --   apply mul_nonneg
+  --   · simp
+  --   · exact NNReal.zero_le_coe
+  -- case G2 =>
+  --   ring_nf
+  --   -- True
+  --   sorry
+  -- case G3 =>
+  --   cases H
+  --   trivial
+
+  -- have X1 : (2 * (zCDP_of_adp δ ε')) ^ (1 / 2)) ^ 2 / 2 = (zCDP_of_adp δ ε') : Real := by sorry
+  -- rw [X1]
+  -- clear X1
+
+  -- let degrade (δ : NNReal) (ε' : NNReal) : NNReal :=
+  --   (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal
+  -- have HDdegrade δ ε' : degrade δ ε' = (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal := by rfl
+  -- exists degrade
+  -- intro δ Hδ ε' ⟨ HN , HB ⟩
+
+
+  -- rename_i Hδ1
+  -- rw [ApproximateDP]
+
+
+
+  -- have R := ApproximateDP_of_zCDP m (degrade δ ε') (by simp) ?G1 HN δ Hδ
+  -- case G1 =>
+  --   -- this proof has to be redone
+  --   sorry
+  -- sorry
 
   /-
   have Hdegrade : ((degrade δ ε') ^ 2) / 2 + (degrade δ ε') * (2 * Real.log (1 / δ))^(1/2 : ℝ) = ε' := by

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -1877,9 +1877,7 @@ Convert ε-DP bound to `(1/2)ε²`-zCDP bound
 
 Note that `zCDPBound _ ε` corresponds to `(1/2)ε²`-zCDP (not `ε`-zCDP).
 -/
-lemma ofDP_bound (ε : NNReal) (q' : List T -> PMF U) (H : SLang.PureDP q' ε) : zCDPBound q' ε := by
-  sorry
-  /-
+lemma ofDP_bound (ε : NNReal) (q' : List T -> PMF U) (H : SLang.PureDP q' ε) : zCDPBound q' ((1/2) * ε^2) := by
   rw [zCDPBound]
   intro α Hα l₁ l₂ HN
   -- Special case: (εα/2 > 1)
@@ -2299,14 +2297,13 @@ lemma ofDP_bound (ε : NNReal) (q' : List T -> PMF U) (H : SLang.PureDP q' ε) :
   apply Eq.le
   congr 1
   linarith
-  -/
 
 /-
 Convert ε-DP to `(1/2)ε²`-zCDP.
 
 Note that `zCDPBound _ ε` corresponds to `(1/2)ε²`-zCDP (not `ε`-zCDP).
 -/
-lemma ofDP (ε : NNReal) (q : List T -> PMF U) (H : SLang.PureDP q ε) : zCDP q ε := by
+lemma ofDP (ε : NNReal) (q : List T -> PMF U) (H : SLang.PureDP q ε) : zCDP q ((1/2) * ε^2) := by
   constructor
   · exact ACNeighbour_of_DP ε q H
   · exact ofDP_bound ε q H

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -63,19 +63,16 @@ lemma zCDP_mono {m : List T -> PMF U} {ε₁ ε₂ : NNReal} (H : ε₁ ≤ ε�
   · assumption
   · rw [zCDPBound] at *
     intro α Hα l₁ l₂ N
-    sorry
-    -- apply (@le_trans _ _ _ (ENNReal.ofReal (1 / 2 * ↑ε₁ ^ 2 * α)) _ (Hε α Hα l₁ l₂ N))
-    -- apply ENNReal.coe_mono
-    -- refine (Real.toNNReal_le_toNNReal_iff ?a.hp).mpr ?a.a
-    -- · apply mul_nonneg
-    --   · apply mul_nonneg
-    --     · simp
-    --     · simp
-    --   · linarith
-    -- · repeat rw [mul_assoc]
-    --   apply (mul_le_mul_iff_of_pos_left (by simp)).mpr
-    --   apply (mul_le_mul_iff_of_pos_right (by linarith)).mpr
-    --   apply pow_le_pow_left' H (OfNat.ofNat 2)
+    apply (@le_trans _ _ _ (ENNReal.ofReal (ε₁ * α)) _ ?G1)
+    case G1 => apply Hε <;> trivial
+    apply ENNReal.coe_mono
+    refine (Real.toNNReal_le_toNNReal_iff ?a.hp).mpr ?a.a
+    · apply mul_nonneg
+      · exact NNReal.zero_le_coe
+      · linarith
+    · apply mul_le_mul_of_nonneg_right
+      · exact H
+      · linarith
 
 /--
 Obtain an approximate DP bound from a zCDP bound, when ε > 0 and δ < 1

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -44,7 +44,7 @@ satisfying this bound are ``ε``-DP).
 -/
 def zCDPBound (q : List T → PMF U) (ε : ℝ) : Prop :=
   ∀ α : ℝ, 1 < α → ∀ l₁ l₂ : List T, Neighbour l₁ l₂ →
-  RenyiDivergence (q l₁) (q l₂) α ≤ ENNReal.ofReal ((1/2) * ε ^ 2 * α)
+  RenyiDivergence (q l₁) (q l₂) α ≤ ENNReal.ofReal ε
 
 /--
 All neighbouring queries are absolutely continuous
@@ -63,18 +63,19 @@ lemma zCDP_mono {m : List T -> PMF U} {ε₁ ε₂ : NNReal} (H : ε₁ ≤ ε�
   · assumption
   · rw [zCDPBound] at *
     intro α Hα l₁ l₂ N
-    apply (@le_trans _ _ _ (ENNReal.ofReal (1 / 2 * ↑ε₁ ^ 2 * α)) _ (Hε α Hα l₁ l₂ N))
-    apply ENNReal.coe_mono
-    refine (Real.toNNReal_le_toNNReal_iff ?a.hp).mpr ?a.a
-    · apply mul_nonneg
-      · apply mul_nonneg
-        · simp
-        · simp
-      · linarith
-    · repeat rw [mul_assoc]
-      apply (mul_le_mul_iff_of_pos_left (by simp)).mpr
-      apply (mul_le_mul_iff_of_pos_right (by linarith)).mpr
-      apply pow_le_pow_left' H (OfNat.ofNat 2)
+    sorry
+    -- apply (@le_trans _ _ _ (ENNReal.ofReal (1 / 2 * ↑ε₁ ^ 2 * α)) _ (Hε α Hα l₁ l₂ N))
+    -- apply ENNReal.coe_mono
+    -- refine (Real.toNNReal_le_toNNReal_iff ?a.hp).mpr ?a.a
+    -- · apply mul_nonneg
+    --   · apply mul_nonneg
+    --     · simp
+    --     · simp
+    --   · linarith
+    -- · repeat rw [mul_assoc]
+    --   apply (mul_le_mul_iff_of_pos_left (by simp)).mpr
+    --   apply (mul_le_mul_iff_of_pos_right (by linarith)).mpr
+    --   apply pow_le_pow_left' H (OfNat.ofNat 2)
 
 /--
 Obtain an approximate DP bound from a zCDP bound, when ε > 0 and δ < 1
@@ -82,6 +83,8 @@ Obtain an approximate DP bound from a zCDP bound, when ε > 0 and δ < 1
 lemma ApproximateDP_of_zCDP_pos_lt_one [Countable U] (m : Mechanism T U)
   (ε : ℝ) (Hε_pos : 0 < ε) (h : zCDPBound m ε) (Hm : ACNeighbour m) :
   ∀ δ : NNReal, (0 < (δ : ℝ)) -> ((δ : ℝ) < 1) -> DP' m (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) δ := by
+  sorry
+  /-
   have Hε : 0 ≤ ε := by exact le_of_lt Hε_pos
   intro δ Hδ0 Hδ1
   generalize Dε' : (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) = ε'
@@ -627,6 +630,7 @@ lemma ApproximateDP_of_zCDP_pos_lt_one [Countable U] (m : Mechanism T U)
 
   -- Conclude by simplification
   simp [add_comm]
+  -/
 
 
 
@@ -1873,6 +1877,8 @@ Convert ε-DP bound to `(1/2)ε²`-zCDP bound
 Note that `zCDPBound _ ε` corresponds to `(1/2)ε²`-zCDP (not `ε`-zCDP).
 -/
 lemma ofDP_bound (ε : NNReal) (q' : List T -> PMF U) (H : SLang.PureDP q' ε) : zCDPBound q' ε := by
+  sorry
+  /-
   rw [zCDPBound]
   intro α Hα l₁ l₂ HN
   -- Special case: (εα/2 > 1)
@@ -2292,6 +2298,7 @@ lemma ofDP_bound (ε : NNReal) (q' : List T -> PMF U) (H : SLang.PureDP q' ε) :
   apply Eq.le
   congr 1
   linarith
+  -/
 
 /-
 Convert ε-DP to `(1/2)ε²`-zCDP.

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/DP.lean
@@ -78,10 +78,8 @@ lemma zCDP_mono {m : List T -> PMF U} {ε₁ ε₂ : NNReal} (H : ε₁ ≤ ε�
 Obtain an approximate DP bound from a zCDP bound, when ε > 0 and δ < 1
 -/
 lemma ApproximateDP_of_zCDP_pos_lt_one [Countable U] (m : Mechanism T U)
-  (ε : ℝ) (Hε_pos : 0 < ε) (h : zCDPBound m ε) (Hm : ACNeighbour m) :
+  (ε : ℝ) (Hε_pos : 0 < ε) (h : zCDPBound m ((1/2) * ε^2)) (Hm : ACNeighbour m) :
   ∀ δ : NNReal, (0 < (δ : ℝ)) -> ((δ : ℝ) < 1) -> DP' m (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) δ := by
-  sorry
-  /-
   have Hε : 0 ≤ ε := by exact le_of_lt Hε_pos
   intro δ Hδ0 Hδ1
   generalize Dε' : (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) = ε'
@@ -627,7 +625,6 @@ lemma ApproximateDP_of_zCDP_pos_lt_one [Countable U] (m : Mechanism T U)
 
   -- Conclude by simplification
   simp [add_comm]
-  -/
 
 
 
@@ -635,12 +632,11 @@ lemma ApproximateDP_of_zCDP_pos_lt_one [Countable U] (m : Mechanism T U)
 Obtain an approximate DP bound from a zCDP bound, when ε > 0
 -/
 lemma ApproximateDP_of_zCDP_pos [Countable U] (m : Mechanism T U)
-    (ε : ℝ) (Hε_pos : 0 < ε) (h : zCDPBound m ε) (Hm : ACNeighbour m) :
+    (ε : ℝ) (Hε_pos : 0 < ε) (h : zCDPBound m ((1/2) * ε^2)) (Hm : ACNeighbour m) :
     ∀ δ : NNReal, (0 < (δ : ℝ)) -> DP' m (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) δ := by
   intro δ Hδ0
   cases (Classical.em (δ < 1))
-  · intro Hδ1
-    apply ApproximateDP_of_zCDP_pos_lt_one m ε Hε_pos h Hm δ Hδ0
+  · apply ApproximateDP_of_zCDP_pos_lt_one m ε Hε_pos h Hm δ Hδ0
     trivial
   · apply ApproximateDP_gt1
     apply le_of_not_lt
@@ -650,7 +646,7 @@ lemma ApproximateDP_of_zCDP_pos [Countable U] (m : Mechanism T U)
 Obtain an approximate DP bound from a zCDP bound
 -/
 theorem ApproximateDP_of_zCDP [Countable U] (m : Mechanism T U)
-    (ε : ℝ) (Hε : 0 ≤ ε) (h : zCDPBound m ε) (Hm : ACNeighbour m) :
+    (ε : ℝ) (Hε : 0 ≤ ε) (h : zCDPBound m ((1/2) * ε^2)) (Hm : ACNeighbour m) :
     ∀ δ : NNReal, (0 < (δ : ℝ)) -> DP' m (ε^2/2 + ε * (2*Real.log (1/δ))^(1/2 : ℝ)) δ := by
   cases LE.le.lt_or_eq Hε
   · rename_i Hε
@@ -674,7 +670,7 @@ zCDP is no weaker than approximate DP, up to a loss of parameters.
 -/
 lemma zCDP_ApproximateDP [Countable U] {m : Mechanism T U} :
     ∃ (degrade : (δ : NNReal) -> (ε' : NNReal) -> NNReal), ∀ (δ : NNReal) (_ : 0 < δ) (ε' : NNReal),
-     (zCDP m (degrade δ ε') -> ApproximateDP m ε' δ) := by
+     (zCDP m (degrade δ ((1/2) * ε'^2)) -> ApproximateDP m ε' δ) := by
   let degrade (δ : NNReal) (ε' : NNReal) : NNReal :=
     (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal
   have HDdegrade δ ε' : degrade δ ε' = (√(2 * Real.log (1/δ) + 2 * ε') - √(2 * Real.log (1/δ))).toNNReal := by rfl
@@ -687,8 +683,15 @@ lemma zCDP_ApproximateDP [Countable U] {m : Mechanism T U} :
 
   rename_i Hδ1
   rw [ApproximateDP]
-  have R := ApproximateDP_of_zCDP m (degrade δ ε') (by simp) HB HN δ Hδ
 
+
+  have R := ApproximateDP_of_zCDP m (degrade δ ε') (by simp) ?G1 HN δ Hδ
+  case G1 =>
+    -- this proof has to be redone
+    sorry
+  sorry
+
+  /-
   have Hdegrade : ((degrade δ ε') ^ 2) / 2 + (degrade δ ε') * (2 * Real.log (1 / δ))^(1/2 : ℝ) = ε' := by
     rw [HDdegrade]
     generalize HD : Real.log (1 / δ) = D
@@ -733,6 +736,7 @@ lemma zCDP_ApproximateDP [Countable U] {m : Mechanism T U} :
     linarith
   rw [Hdegrade] at R
   trivial
+  -/
 
 
 /--

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
@@ -29,6 +29,8 @@ theorem privNoisedQuery_zCDPBound (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ
   have A := @discrete_GaussianGenSample_ZeroConcentrated α h1 (Δ * ε₂) ε₁ (query l₁) (query l₂)
   apply le_trans A
   clear A
+  sorry
+  /-
 
   -- Turn it into an equality ASAP
   rw [sensitivity] at bounded_sensitivity
@@ -186,6 +188,7 @@ theorem privNoisedQuery_zCDPBound (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ
     case G1 => exact NNReal.zero_le_coe
     congr
     simp only [Real.toNNReal_coe]
+    -/
 
 lemma discrete_gaussian_shift {σ : ℝ} (h : σ ≠ 0) (μ : ℝ) (τ x : ℤ) :
   discrete_gaussian σ μ (x - τ) = discrete_gaussian σ (μ + τ) (x) := by

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
@@ -23,14 +23,12 @@ namespace SLang
 The zCDP mechanism with bounded sensitivity satisfies the bound for ``(Δε₂/ε₁)^2``-zCDP.
 -/
 theorem privNoisedQuery_zCDPBound (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (bounded_sensitivity : sensitivity query Δ) :
-  zCDPBound (privNoisedQuery query Δ ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
+  zCDPBound (privNoisedQuery query Δ ε₁ ε₂) ((1/2) * ((ε₁ : NNReal) / ε₂) ^ 2) := by
   simp [zCDPBound, privNoisedQuery]
   intros α h1 l₁ l₂ h2
   have A := @discrete_GaussianGenSample_ZeroConcentrated α h1 (Δ * ε₂) ε₁ (query l₁) (query l₂)
   apply le_trans A
   clear A
-  sorry
-  /-
 
   -- Turn it into an equality ASAP
   rw [sensitivity] at bounded_sensitivity
@@ -188,7 +186,6 @@ theorem privNoisedQuery_zCDPBound (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ
     case G1 => exact NNReal.zero_le_coe
     congr
     simp only [Real.toNNReal_coe]
-    -/
 
 lemma discrete_gaussian_shift {σ : ℝ} (h : σ ≠ 0) (μ : ℝ) (τ x : ℤ) :
   discrete_gaussian σ μ (x - τ) = discrete_gaussian σ (μ + τ) (x) := by
@@ -228,8 +225,9 @@ theorem privNoisedQuery_zCDP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (b
   simp [zCDP]
   apply And.intro
   · exact privNoisedQuery_AC query Δ ε₁ ε₂
-  · apply privNoisedQuery_zCDPBound
-    exact bounded_sensitivity
+  · sorry
+    -- apply privNoisedQuery_zCDPBound
+    -- exact bounded_sensitivity
 
 
 end SLang

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/Mechanism/Properties.lean
@@ -221,13 +221,11 @@ def privNoisedQuery_AC (query : List T -> ℤ) (Δ ε₁ ε₂ : ℕ+) : ACNeigh
 The zCDP mechanism is ``(Δε₂/ε₁)^2``-zCDP.
 -/
 theorem privNoisedQuery_zCDP (query : List T → ℤ) (Δ ε₁ ε₂ : ℕ+) (bounded_sensitivity : sensitivity query Δ) :
-  zCDP (privNoisedQuery query Δ ε₁ ε₂) ((ε₁ : NNReal) / ε₂) := by
-  simp [zCDP]
+  zCDP (privNoisedQuery query Δ ε₁ ε₂) ((1/2) * ((ε₁ : NNReal) / ε₂) ^ 2) := by
+  simp only [zCDP]
   apply And.intro
   · exact privNoisedQuery_AC query Δ ε₁ ε₂
-  · sorry
-    -- apply privNoisedQuery_zCDPBound
-    -- exact bounded_sensitivity
-
+  · apply privNoisedQuery_zCDPBound
+    exact bounded_sensitivity
 
 end SLang

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/Postprocessing.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/Postprocessing.lean
@@ -37,6 +37,7 @@ def privPostProcess_AC {f : U -> V} (nq : Mechanism T U) (Hac : ACNeighbour nq) 
   intro l₁ l₂ Hn v
   have Hac := Hac l₁ l₂ Hn
   simp [privPostProcess]
+  simp [DFunLike.coe, SPMF.instFunLike]
   intro Hppz i fi
   apply Hac
   apply Hppz
@@ -575,8 +576,6 @@ theorem privPostProcess_zCDPBound {nq : Mechanism T U} {ε : ℝ}
     apply inv_nonneg_of_nonneg
     linarith
   apply elog_mono_le.mp
-  simp [PMF.bind, PMF.pure]
-  simp [PMF.instFunLike]
   apply privPostPocess_DP_pre
   · exact fun l => PMF.hasSum_coe_one (nq l)
   · exact h1

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -27,28 +27,48 @@ instance zCDPSystem : DPSystem T where
   prop := zCDP
   of_adp := sorry
   prop_adp := sorry -- zCDP_ApproximateDP
-  prop_mono := sorry -- zCDP_mono
-  -- noise := privNoisedQuery
-  -- noise_prop := sorry -- privNoisedQuery_zCDP
-  adaptive_compose_prop := sorry -- privComposeAdaptive_zCDP
-  postprocess_prop := sorry -- privPostProcess_zCDP
-  const_prop := sorry -- privConst_zCDP
+  prop_mono := by
+    intro _ _ _ _ H HZ
+    apply zCDP_mono H HZ
+  adaptive_compose_prop := by
+    intros _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HZ HZ2 Hε
+    rw [<- Hε]
+    apply privComposeAdaptive_zCDP
+    apply HZ
+    apply HZ2
+  postprocess_prop := by
+    intros _ _ _ _ _ _ _ _ _ HZ
+    apply privPostProcess_zCDP
+    apply HZ
+  const_prop := by
+    intros _ _ _ _ _ _ Hε
+    rw [Hε]
+    apply privConst_zCDP
+
+def gaussian_zCDP_noise_priv (ε₁ ε₂ : ℕ+) (ε : NNReal) : Prop := (1/2) * ((ε₁ : NNReal) / ε₂)^2 ≤ ε
 
 /--
 Gaussian noise for zCDP system
 -/
-instance gaussian_zCDPSystem : DPNoise zCDPsystem where
+instance gaussian_zCDPSystem (T : Type) : DPNoise (@zCDPSystem T) where
   noise := privNoisedQuery
-  noise_priv := sorry
-  noise_prop := sorry -- privNoisedQuery_zCDP
+  noise_priv := gaussian_zCDP_noise_priv
+  noise_prop := by
+    intros _ _ _ _ _ H HS
+    apply DPSystem.prop_mono ?G1
+    · simp [DPSystem.prop]
+      apply privNoisedQuery_zCDP
+      apply HS
+    · apply H
 
-/--
-Laplace noise for zCDP system
--/
-instance laplace_zCDPSystem : DPNoise zCDPsystem where
-  noise := sorry
-  noise_priv := sorry
-  noise_prop := sorry -- privNoisedQuery_zCDP
+
+-- /-
+-- Laplace noise for zCDP system?
+-- -/
+-- instance laplace_zCDPSystem (T : Type) : DPNoise (@zCDPSystem T) where
+--   noise := sorry
+--   noise_priv := sorry
+--   noise_prop := sorry -- privNoisedQuery_zCDP
 
 
 end SLang

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -30,9 +30,9 @@ instance zCDPSystem : DPSystem T where
   prop_mono := zCDP_mono
   -- noise := privNoisedQuery
   -- noise_prop := sorry -- privNoisedQuery_zCDP
-  adaptive_compose_prop := privComposeAdaptive_zCDP
+  adaptive_compose_prop := sorry -- privComposeAdaptive_zCDP
   postprocess_prop := privPostProcess_zCDP
-  const_prop := privConst_zCDP
+  const_prop := sorry -- privConst_zCDP
 
 /--
 Gaussian noise for zCDP system

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -27,7 +27,7 @@ Instance of a DP system for zCDP
 -/
 instance zCDPSystem : DPSystem T where
   prop := zCDP
-  of_adp := zCDP_of_adp
+  of_app_dp := zCDP_of_adp
   prop_adp := by
     intros; apply zCDP_ApproximateDP <;> assumption
   prop_mono := by

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -27,11 +27,11 @@ instance zCDPSystem : DPSystem T where
   prop := zCDP
   of_adp := sorry
   prop_adp := sorry -- zCDP_ApproximateDP
-  prop_mono := zCDP_mono
+  prop_mono := sorry -- zCDP_mono
   -- noise := privNoisedQuery
   -- noise_prop := sorry -- privNoisedQuery_zCDP
   adaptive_compose_prop := sorry -- privComposeAdaptive_zCDP
-  postprocess_prop := privPostProcess_zCDP
+  postprocess_prop := sorry -- privPostProcess_zCDP
   const_prop := sorry -- privConst_zCDP
 
 /--

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -21,16 +21,34 @@ namespace SLang
 variable { T : Type }
 
 /--
-Instance of a DP system for zCDP, using the discrete Gaussian as a noising mechanism.
+Instance of a DP system for zCDP
 -/
-noncomputable instance gaussian_zCDPSystem : DPSystem T where
+instance zCDPSystem : DPSystem T where
   prop := zCDP
+  of_adp := sorry
   prop_adp := sorry -- zCDP_ApproximateDP
   prop_mono := zCDP_mono
-  noise := privNoisedQuery
-  noise_prop := sorry -- privNoisedQuery_zCDP
+  -- noise := privNoisedQuery
+  -- noise_prop := sorry -- privNoisedQuery_zCDP
   adaptive_compose_prop := privComposeAdaptive_zCDP
   postprocess_prop := privPostProcess_zCDP
   const_prop := privConst_zCDP
+
+/--
+Gaussian noise for zCDP system
+-/
+instance gaussian_zCDPSystem : DPNoise zCDPsystem where
+  noise := privNoisedQuery
+  noise_priv := sorry
+  noise_prop := sorry -- privNoisedQuery_zCDP
+
+/--
+Laplace noise for zCDP system
+-/
+instance laplace_zCDPSystem : DPNoise zCDPsystem where
+  noise := sorry
+  noise_priv := sorry
+  noise_prop := sorry -- privNoisedQuery_zCDP
+
 
 end SLang

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -34,17 +34,17 @@ instance zCDPSystem : DPSystem T where
     intro _ _ _ _ H HZ
     apply zCDP_mono H HZ
   adaptive_compose_prop := by
-    intros _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ HZ HZ2 Hε
+    intros _ _ _ _ _ _ _ _ _ HZ HZ2 Hε
     rw [<- Hε]
     apply privComposeAdaptive_zCDP
     apply HZ
     apply HZ2
   postprocess_prop := by
-    intros _ _ _ _ _ _ _ _ _ HZ
+    intros _ _ _ _ _ _ HZ
     apply privPostProcess_zCDP
     apply HZ
   const_prop := by
-    intros _ _ _ _ _ _ Hε
+    intros _ _ _ _ Hε
     rw [Hε]
     apply privConst_zCDP
 

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -25,10 +25,10 @@ Instance of a DP system for zCDP, using the discrete Gaussian as a noising mecha
 -/
 noncomputable instance gaussian_zCDPSystem : DPSystem T where
   prop := zCDP
-  prop_adp := zCDP_ApproximateDP
+  prop_adp := sorry -- zCDP_ApproximateDP
   prop_mono := zCDP_mono
   noise := privNoisedQuery
-  noise_prop := privNoisedQuery_zCDP
+  noise_prop := sorry -- privNoisedQuery_zCDP
   adaptive_compose_prop := privComposeAdaptive_zCDP
   postprocess_prop := privPostProcess_zCDP
   const_prop := privConst_zCDP

--- a/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
+++ b/SampCert/DifferentialPrivacy/ZeroConcentrated/System.lean
@@ -16,6 +16,8 @@ import SampCert.DifferentialPrivacy.ZeroConcentrated.Const
 This file contains an instance of an abstract DP system associated to the discrete gaussian mechanisms.
 -/
 
+noncomputable section
+
 namespace SLang
 
 variable { T : Type }
@@ -25,8 +27,9 @@ Instance of a DP system for zCDP
 -/
 instance zCDPSystem : DPSystem T where
   prop := zCDP
-  of_adp := sorry
-  prop_adp := sorry -- zCDP_ApproximateDP
+  of_adp := zCDP_of_adp
+  prop_adp := by
+    intros; apply zCDP_ApproximateDP <;> assumption
   prop_mono := by
     intro _ _ _ _ H HZ
     apply zCDP_mono H HZ

--- a/SampCert/Samplers/Uniform/Properties.lean
+++ b/SampCert/Samplers/Uniform/Properties.lean
@@ -249,7 +249,7 @@ theorem UniformSample_HasSum_1  (n : PNat) :
 /--
 Conversion of ``UniformSample`` from a ``SLang`` term to a ``PMF``.
 -/
-noncomputable def UniformSample_PMF (n : PNat) : PMF ℕ := ⟨ UniformSample n , UniformSample_HasSum_1 n⟩
+def UniformSample_PMF (n : PNat) : SPMF ℕ := ⟨ UniformSample n , UniformSample_HasSum_1 n⟩
 
 /--
 Evaluation of ``UniformSample`` on ``ℕ`` guarded by its support, when inside the support.

--- a/Test.lean
+++ b/Test.lean
@@ -6,6 +6,7 @@ Authors: Jean-Baptiste Tristan
 import SampCert
 import SampCert.SLang
 import SampCert.Samplers.Gaussian.Properties
+import Init.Data.Float
 
 open SLang Std Int Array PMF
 
@@ -173,7 +174,61 @@ def test (num den : ℕ+) (mix numSamples : ℕ) (threshold : Float) : IO Unit :
   IO.println s!"Kolmogorov distance = {D}"
 
 
-def main : IO Unit := do
+def query_tests : IO Unit := do
+  -- Generate list of 1000 numbers from 0 to 15
+  let samples := 10000
+  let unif_ub := 10
+  let data : List ℕ <- List.mapM (fun _ => run <| (SLang.UniformSample_PMF unif_ub)) (List.replicate samples 0)
+
+  let num : ℕ+ := 9
+  let den : ℕ+ := 2
+  let num_trials := 5
+
+  IO.println s!"[query] testing pure ({(num : ℕ)} / {(den : ℕ)})-DP queries"
+  IO.println s!"data := {samples} uniform samples of [0, {(unif_ub : ℕ)}): {(data.take 20)}..."
+  IO.println ""
+
+  for i in [:num_trials] do
+    let ct <- run <| @privNoisedCount _ PureDPSystem laplace_pureDPSystem num den data
+    IO.println s!"#{i} count: {ct}"
+  IO.println ""
+
+  let sum_bound : ℕ+ := 10
+  for i in [:num_trials] do
+    let bs <- run <| @privNoisedBoundedSum PureDPSystem laplace_pureDPSystem sum_bound num den data
+    IO.println s!"#{i} bounded sum (bound = {(sum_bound : ℕ)}): {bs}"
+  IO.println ""
+
+  for i in [:num_trials] do
+    let bs <- run <| @privNoisedBoundedMean PureDPSystem laplace_pureDPSystem sum_bound num den data
+    let float_bs := Float.div (Float.ofInt bs.1) (Float.ofInt bs.2)
+    IO.println s!"#{i} bounded mean (bound = {(sum_bound : ℕ)}): {bs} (~{float_bs})"
+  IO.println ""
+
+  for i in [:num_trials] do
+    let h <- run <| @privNoisedHistogram numBins _ { bin := example_bin } PureDPSystem laplace_pureDPSystem num den data
+    let h' : List ℤ := h.count.toList.take 25
+    IO.println s!"#{i} histogram : {h'}..."
+  IO.println ""
+
+  let thresh := 100
+  for i in [:num_trials] do
+    let m <- run <| @privMaxBinAboveThreshold numBins _ { bin := example_bin } PureDPSystem laplace_pureDPSystem num den thresh data
+    IO.println s!"#{i} max bin above threshold (threshold = {(thresh : ℤ)}): {m}"
+  IO.println ""
+
+  let τ := 100
+  for i in [:num_trials] do
+    let m <- run <| @privMeanHistogram PureDPSystem laplace_pureDPSystem numBins { bin := example_bin } unbin num den τ num den data
+    let m_float :=
+      match m with
+      | none => none
+      | some bs => some (Float.div (Float.ofInt bs.1) (Float.ofInt bs.2))
+    IO.println s!"#{i} (0.5x-privacy) histogram mean, τ = {τ}: {m} (~{m_float})"
+  IO.println ""
+
+def statistical_tests : IO Unit := do
+  IO.println s!"[samplers] statistical tests"
   let tests : List (ℕ+ × ℕ+ × ℕ) := [
     -- (1,1,0),
     (1,1,7),
@@ -188,3 +243,8 @@ def main : IO Unit := do
   for (num,den,mix) in tests do
     IO.println s!"num = {(num : ℕ)}, den = {(den : ℕ)}, mix = {mix}"
     test num den mix 100000 0.1
+
+
+def main : IO Unit := do
+  query_tests
+  statistical_tests


### PR DESCRIPTION
- [x] reparameterize zCDP to address issue #45 
- [x] Separate noise fields out of abstract DP interface
- [x] Move adp ``degrade`` function into separate field
- [x] Fix computability of abstract DP instances
- [x] Add top-level query executions 
- [x] Improve tactic support for abstract DP proofs 
  - Instead of writing tactics, I tweaked the definitions in abstract DP so that they could infer the right terms. The instantiation code looks uglier but it's a good price to pay for easier to read abstract proofs. See ??  
- [x] Typeclass synonym for discrete probability to simplify abstract definition
- [x] Simplify histogram proof